### PR TITLE
feat(release): automate openapi sync + release versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ concurrency:
 
 jobs:
   release:
+    # Prevent an infinite loop when this workflow pushes its own release commit.
     if: >-
       ${{ github.event_name != 'push' ||
       !startsWith(github.event.head_commit.message, 'chore(release): v') }}
@@ -65,21 +66,21 @@ jobs:
             SHOULD_RELEASE="true"
             REASON="no-existing-tags"
           else
-            CURRENT_OPENAPI=$(node -e "const pkg=require('./packages/nx-plugin/package.json'); const dep=pkg.dependencies?.['@hey-api/openapi-ts']; const m=(dep || '').match(/(\\d+\\.\\d+\\.\\d+)/); if (!m) throw new Error('Missing @hey-api/openapi-ts dependency version'); process.stdout.write(m[1]);")
-            PREVIOUS_OPENAPI=$(git show "${LAST_TAG}:packages/nx-plugin/package.json" | node -e "const fs=require('node:fs'); const pkg=JSON.parse(fs.readFileSync(0, 'utf8')); const dep=pkg.dependencies?.['@hey-api/openapi-ts']; const m=(dep || '').match(/(\\d+\\.\\d+\\.\\d+)/); if (!m) throw new Error('Missing @hey-api/openapi-ts dependency version in last tag'); process.stdout.write(m[1]);")
+            CURRENT_OPENAPI=$(node ./packages/nx-plugin/scripts/openapi-version.mjs)
+            PREVIOUS_OPENAPI=$(node ./packages/nx-plugin/scripts/openapi-version.mjs --ref "${LAST_TAG}" 2>/dev/null || echo "unknown")
 
             if [[ "${CURRENT_OPENAPI}" != "${PREVIOUS_OPENAPI}" ]]; then
               MODE="sync"
               SHOULD_RELEASE="true"
               REASON="openapi-changed-${PREVIOUS_OPENAPI}-to-${CURRENT_OPENAPI}"
-            elif git diff --quiet "${LAST_TAG}"..HEAD -- packages/nx-plugin; then
-              MODE="none"
-              SHOULD_RELEASE="false"
-              REASON="no-plugin-changes-since-${LAST_TAG}"
-            else
+            elif ! git diff --quiet "${LAST_TAG}"..HEAD -- packages/nx-plugin; then
               MODE="patch"
               SHOULD_RELEASE="true"
               REASON="plugin-changes-since-${LAST_TAG}"
+            else
+              MODE="none"
+              SHOULD_RELEASE="false"
+              REASON="no-plugin-changes-since-${LAST_TAG}"
             fi
           fi
 
@@ -121,42 +122,27 @@ jobs:
 
           echo "skip_existing_tag=false" >> $GITHUB_OUTPUT
 
-      - name: Create release commit
+      - name: Create release artifacts and push
         if: ${{ steps.strategy.outputs.should_release == 'true' && steps.tag.outputs.skip_existing_tag != 'true' }}
-        id: release_commit
         shell: bash
         run: |
           set -euo pipefail
 
+          TAG="${{ steps.tag.outputs.tag }}"
+
           if git diff --quiet -- packages/nx-plugin/package.json; then
-            echo "No version change detected in packages/nx-plugin/package.json. Using current HEAD for tag."
-            echo "created_commit=false" >> $GITHUB_OUTPUT
+            echo "No version change detected in packages/nx-plugin/package.json. Tagging current HEAD."
+            git tag "${TAG}"
+            git push origin "${TAG}"
             exit 0
           fi
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add packages/nx-plugin/package.json
-          git commit -m "chore(release): ${{ steps.tag.outputs.tag }}"
-          echo "created_commit=true" >> $GITHUB_OUTPUT
-
-      - name: Create release tag
-        if: ${{ steps.strategy.outputs.should_release == 'true' && steps.tag.outputs.skip_existing_tag != 'true' }}
-        shell: bash
-        run: |
-          git tag "${{ steps.tag.outputs.tag }}"
-
-      - name: Push release commit
-        if: ${{ steps.release_commit.outputs.created_commit == 'true' }}
-        shell: bash
-        run: |
-          git push origin HEAD:main
-
-      - name: Push release tag
-        if: ${{ steps.strategy.outputs.should_release == 'true' && steps.tag.outputs.skip_existing_tag != 'true' }}
-        shell: bash
-        run: |
-          git push origin "${{ steps.tag.outputs.tag }}"
+          git commit -m "chore(release): ${TAG}"
+          git tag "${TAG}"
+          git push origin HEAD:main "${TAG}"
 
       - name: No release
         if: ${{ steps.strategy.outputs.should_release != 'true' || steps.tag.outputs.skip_existing_tag == 'true' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,22 @@
 name: Release
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - packages/nx-plugin/**
+      - .github/workflows/release.yml
   workflow_dispatch:
+    inputs:
+      release_mode:
+        description: Release mode
+        required: false
+        type: choice
+        default: auto
+        options:
+          - auto
+          - sync
+          - patch
 
 concurrency:
   group: release-main
@@ -9,6 +24,9 @@ concurrency:
 
 jobs:
   release:
+    if: >-
+      ${{ github.event_name != 'push' ||
+      !startsWith(github.event.head_commit.message, 'chore(release): v') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -24,57 +42,125 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '24'
-          registry-url: 'https://registry.npmjs.org'
 
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        with:
-          version: 9
-          run_install: false
-
-      - name: Get pnpm store directory
+      - name: Determine release strategy
+        id: strategy
         shell: bash
+        env:
+          REQUESTED_MODE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_mode || 'auto' }}
         run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+          set -euo pipefail
 
-      - uses: actions/cache@v5
-        name: Setup pnpm cache
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+          LAST_TAG=$(git tag --sort=-version:refname | head -n 1 || true)
+          MODE="none"
+          SHOULD_RELEASE="false"
+          REASON=""
 
-      - name: Install dependencies
-        run: pnpm install
+          if [[ "${REQUESTED_MODE}" != "auto" ]]; then
+            MODE="${REQUESTED_MODE}"
+            SHOULD_RELEASE="true"
+            REASON="manual-${REQUESTED_MODE}"
+          elif [[ -z "${LAST_TAG}" ]]; then
+            MODE="sync"
+            SHOULD_RELEASE="true"
+            REASON="no-existing-tags"
+          else
+            CURRENT_OPENAPI=$(node -e "const pkg=require('./packages/nx-plugin/package.json'); const dep=pkg.dependencies?.['@hey-api/openapi-ts']; const m=(dep || '').match(/(\\d+\\.\\d+\\.\\d+)/); if (!m) throw new Error('Missing @hey-api/openapi-ts dependency version'); process.stdout.write(m[1]);")
+            PREVIOUS_OPENAPI=$(git show "${LAST_TAG}:packages/nx-plugin/package.json" | node -e "const fs=require('node:fs'); const pkg=JSON.parse(fs.readFileSync(0, 'utf8')); const dep=pkg.dependencies?.['@hey-api/openapi-ts']; const m=(dep || '').match(/(\\d+\\.\\d+\\.\\d+)/); if (!m) throw new Error('Missing @hey-api/openapi-ts dependency version in last tag'); process.stdout.write(m[1]);")
 
-      - name: Sync nx-plugin version from policy
-        run: pnpm run version:sync:nx-plugin
-
-      - name: Verify nx-plugin version policy
-        run: pnpm run version:check:nx-plugin
-
-      - name: Create release commit and tag
-        shell: bash
-        run: |
-          VERSION=$(node -p "require('./packages/nx-plugin/package.json').version")
-          TAG="v${VERSION}"
-          echo "TAG=${TAG}" >> $GITHUB_ENV
-
-          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
-            echo "Tag ${TAG} already exists."
-            exit 1
+            if [[ "${CURRENT_OPENAPI}" != "${PREVIOUS_OPENAPI}" ]]; then
+              MODE="sync"
+              SHOULD_RELEASE="true"
+              REASON="openapi-changed-${PREVIOUS_OPENAPI}-to-${CURRENT_OPENAPI}"
+            elif git diff --quiet "${LAST_TAG}"..HEAD -- packages/nx-plugin; then
+              MODE="none"
+              SHOULD_RELEASE="false"
+              REASON="no-plugin-changes-since-${LAST_TAG}"
+            else
+              MODE="patch"
+              SHOULD_RELEASE="true"
+              REASON="plugin-changes-since-${LAST_TAG}"
+            fi
           fi
 
+          echo "mode=${MODE}" >> $GITHUB_OUTPUT
+          echo "should_release=${SHOULD_RELEASE}" >> $GITHUB_OUTPUT
+          echo "reason=${REASON}" >> $GITHUB_OUTPUT
+          echo "last_tag=${LAST_TAG}" >> $GITHUB_OUTPUT
+          echo "Release strategy: mode=${MODE}, should_release=${SHOULD_RELEASE}, reason=${REASON}, last_tag=${LAST_TAG}"
+
+      - name: Sync nx-plugin version to openapi version
+        if: ${{ steps.strategy.outputs.should_release == 'true' && steps.strategy.outputs.mode == 'sync' }}
+        run: node ./packages/nx-plugin/scripts/version-with-openapi.mjs --sync
+
+      - name: Bump nx-plugin patch version
+        if: ${{ steps.strategy.outputs.should_release == 'true' && steps.strategy.outputs.mode == 'patch' }}
+        run: node ./packages/nx-plugin/scripts/version-with-openapi.mjs --bump-patch
+
+      - name: Verify nx-plugin version policy
+        if: ${{ steps.strategy.outputs.should_release == 'true' }}
+        run: node ./packages/nx-plugin/scripts/version-with-openapi.mjs --check
+
+      - name: Prepare release tag
+        if: ${{ steps.strategy.outputs.should_release == 'true' }}
+        id: tag
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          VERSION=$(node -p "require('./packages/nx-plugin/package.json').version")
+          TAG="v${VERSION}"
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists. Skipping release."
+            echo "skip_existing_tag=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "skip_existing_tag=false" >> $GITHUB_OUTPUT
+
+      - name: Create release commit
+        if: ${{ steps.strategy.outputs.should_release == 'true' && steps.tag.outputs.skip_existing_tag != 'true' }}
+        id: release_commit
+        shell: bash
+        run: |
+          set -euo pipefail
+
           if git diff --quiet -- packages/nx-plugin/package.json; then
-            echo "No version change detected in packages/nx-plugin/package.json."
-            exit 1
+            echo "No version change detected in packages/nx-plugin/package.json. Using current HEAD for tag."
+            echo "created_commit=false" >> $GITHUB_OUTPUT
+            exit 0
           fi
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add packages/nx-plugin/package.json
-          git commit -m "chore(release): ${TAG}"
-          git tag "${TAG}"
+          git commit -m "chore(release): ${{ steps.tag.outputs.tag }}"
+          echo "created_commit=true" >> $GITHUB_OUTPUT
+
+      - name: Create release tag
+        if: ${{ steps.strategy.outputs.should_release == 'true' && steps.tag.outputs.skip_existing_tag != 'true' }}
+        shell: bash
+        run: |
+          git tag "${{ steps.tag.outputs.tag }}"
+
+      - name: Push release commit
+        if: ${{ steps.release_commit.outputs.created_commit == 'true' }}
+        shell: bash
+        run: |
           git push origin HEAD:main
-          git push origin "${TAG}"
+
+      - name: Push release tag
+        if: ${{ steps.strategy.outputs.should_release == 'true' && steps.tag.outputs.skip_existing_tag != 'true' }}
+        shell: bash
+        run: |
+          git push origin "${{ steps.tag.outputs.tag }}"
+
+      - name: No release
+        if: ${{ steps.strategy.outputs.should_release != 'true' || steps.tag.outputs.skip_existing_tag == 'true' }}
+        shell: bash
+        run: |
+          echo "Release skipped."
+          echo "reason=${{ steps.strategy.outputs.reason }}"

--- a/.github/workflows/sync-openapi.yml
+++ b/.github/workflows/sync-openapi.yml
@@ -1,0 +1,77 @@
+name: Sync OpenAPI Dependency
+
+on:
+  schedule:
+    - cron: '0 12 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: sync-openapi-main
+  cancel-in-progress: false
+
+jobs:
+  sync-openapi:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          version: 9
+          run_install: false
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Update @hey-api/openapi-ts version range
+        id: update_dep
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          LATEST_OPENAPI=$(npm view @hey-api/openapi-ts version)
+          echo "latest_openapi=${LATEST_OPENAPI}" >> $GITHUB_OUTPUT
+
+          CURRENT_OPENAPI=$(node -e "const pkg=require('./packages/nx-plugin/package.json'); const dep=pkg.dependencies?.['@hey-api/openapi-ts']; const m=(dep || '').match(/(\\d+\\.\\d+\\.\\d+)/); if (!m) throw new Error('Missing @hey-api/openapi-ts dependency version'); process.stdout.write(m[1]);")
+          echo "current_openapi=${CURRENT_OPENAPI}" >> $GITHUB_OUTPUT
+
+          if [[ "${CURRENT_OPENAPI}" == "${LATEST_OPENAPI}" ]]; then
+            echo "updated=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          node -e "const fs=require('node:fs'); const path='packages/nx-plugin/package.json'; const pkg=JSON.parse(fs.readFileSync(path, 'utf8')); pkg.dependencies['@hey-api/openapi-ts']=`^${process.argv[1]}`; fs.writeFileSync(path, `${JSON.stringify(pkg, null, 2)}\\n`);" "${LATEST_OPENAPI}"
+          echo "updated=true" >> $GITHUB_OUTPUT
+
+      - name: Update lockfile
+        if: ${{ steps.update_dep.outputs.updated == 'true' }}
+        run: pnpm install --lockfile-only
+
+      - name: Commit and push dependency update
+        if: ${{ steps.update_dep.outputs.updated == 'true' }}
+        shell: bash
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add packages/nx-plugin/package.json pnpm-lock.yaml
+          git commit -m "chore(deps): bump @hey-api/openapi-ts to ^${{ steps.update_dep.outputs.latest_openapi }}"
+          git push origin HEAD:main
+
+      - name: No dependency changes
+        if: ${{ steps.update_dep.outputs.updated != 'true' }}
+        run: |
+          echo "No update needed. current=${{ steps.update_dep.outputs.current_openapi }} latest=${{ steps.update_dep.outputs.latest_openapi }}"

--- a/.github/workflows/sync-openapi.yml
+++ b/.github/workflows/sync-openapi.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: sync-openapi-main
+  group: release-main
   cancel-in-progress: false
 
 jobs:
@@ -46,7 +46,7 @@ jobs:
           LATEST_OPENAPI=$(npm view @hey-api/openapi-ts version)
           echo "latest_openapi=${LATEST_OPENAPI}" >> $GITHUB_OUTPUT
 
-          CURRENT_OPENAPI=$(node -e "const pkg=require('./packages/nx-plugin/package.json'); const dep=pkg.dependencies?.['@hey-api/openapi-ts']; const m=(dep || '').match(/(\\d+\\.\\d+\\.\\d+)/); if (!m) throw new Error('Missing @hey-api/openapi-ts dependency version'); process.stdout.write(m[1]);")
+          CURRENT_OPENAPI=$(node ./packages/nx-plugin/scripts/openapi-version.mjs)
           echo "current_openapi=${CURRENT_OPENAPI}" >> $GITHUB_OUTPUT
 
           if [[ "${CURRENT_OPENAPI}" == "${LATEST_OPENAPI}" ]]; then
@@ -54,7 +54,7 @@ jobs:
             exit 0
           fi
 
-          node -e "const fs=require('node:fs'); const path='packages/nx-plugin/package.json'; const pkg=JSON.parse(fs.readFileSync(path, 'utf8')); pkg.dependencies['@hey-api/openapi-ts']=`^${process.argv[1]}`; fs.writeFileSync(path, `${JSON.stringify(pkg, null, 2)}\\n`);" "${LATEST_OPENAPI}"
+          node ./packages/nx-plugin/scripts/openapi-version.mjs --set "${LATEST_OPENAPI}"
           echo "updated=true" >> $GITHUB_OUTPUT
 
       - name: Update lockfile

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "lint:fix": "nx run-many --target=lint -- --fix",
     "prepare": "lefthook install",
     "version:check:nx-plugin": "node ./packages/nx-plugin/scripts/version-with-openapi.mjs --check",
-    "version:sync:nx-plugin": "node ./packages/nx-plugin/scripts/version-with-openapi.mjs --write",
+    "version:sync:nx-plugin": "node ./packages/nx-plugin/scripts/version-with-openapi.mjs --sync",
+    "version:bump:nx-plugin": "node ./packages/nx-plugin/scripts/version-with-openapi.mjs --bump-patch",
     "test": "nx run-many --target=test",
     "publish": "nx run-many --target=publish"
   },

--- a/packages/nx-plugin/README.md
+++ b/packages/nx-plugin/README.md
@@ -12,10 +12,12 @@ npm install -D @seriouslag/nx-openapi-ts-plugin
 
 This package version tracks `@hey-api/openapi-ts`:
 
-- Major/minor must match `@hey-api/openapi-ts`.
-- Patch can be equal or ahead.
-- For plugin-only patch releases, increment patch by one.
-- When `@hey-api/openapi-ts` patch updates, release the plugin at least one patch ahead of the greater of current plugin/openapi patch.
+- For upstream releases, match `@hey-api/openapi-ts` exactly.
+  Example: if openapi-ts is `0.93.0`, plugin release is `0.93.0`.
+- For plugin-only releases, bump patch by one while keeping major/minor aligned.
+  Example: `0.93.0` -> `0.93.1`.
+- If openapi-ts later catches up to the same patch, release at that exact upstream version.
+  Example: plugin `0.93.1` and openapi-ts `0.93.1` are aligned.
 
 Helpful commands:
 
@@ -23,8 +25,11 @@ Helpful commands:
 # verify policy
 pnpm run version:check:nx-plugin
 
-# update packages/nx-plugin/package.json version to the recommended next value
+# set package version to match @hey-api/openapi-ts
 pnpm run version:sync:nx-plugin
+
+# bump patch for plugin-only releases
+pnpm run version:bump:nx-plugin
 ```
 
 ## Usage

--- a/packages/nx-plugin/README.md
+++ b/packages/nx-plugin/README.md
@@ -32,6 +32,11 @@ pnpm run version:sync:nx-plugin
 pnpm run version:bump:nx-plugin
 ```
 
+Automation in CI:
+
+- `Sync OpenAPI Dependency` checks npm daily and updates `@hey-api/openapi-ts` in this repo.
+- `Release` then syncs plugin version to the upstream version for dependency bumps, or applies patch bumps for plugin-only changes.
+
 ## Usage
 
 ### Generators

--- a/packages/nx-plugin/scripts/openapi-version.mjs
+++ b/packages/nx-plugin/scripts/openapi-version.mjs
@@ -1,0 +1,110 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const pluginPackageJsonPath = join(
+  process.cwd(),
+  'packages/nx-plugin/package.json',
+);
+
+export function parseVersionFromRange(versionRange) {
+  const match = versionRange.match(/(\d+\.\d+\.\d+)/);
+  if (!match) {
+    throw new Error(`Could not extract version from range: ${versionRange}`);
+  }
+
+  return match[1];
+}
+
+function parseArgs(argv) {
+  let ref = null;
+  let setVersion = null;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--ref') {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error('Missing value for --ref');
+      }
+      ref = value;
+      i += 1;
+      continue;
+    }
+
+    if (arg === '--set') {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error('Missing value for --set');
+      }
+      setVersion = value;
+      i += 1;
+      continue;
+    }
+  }
+
+  return { ref, setVersion };
+}
+
+function getDependencyRangeFromPackageJson(packageJson, context) {
+  const dep = packageJson.dependencies?.['@hey-api/openapi-ts'];
+  if (!dep) {
+    throw new Error(
+      `Missing dependency @hey-api/openapi-ts in ${context}`,
+    );
+  }
+
+  return dep;
+}
+
+function readCurrentPackageJson() {
+  return JSON.parse(readFileSync(pluginPackageJsonPath, 'utf8'));
+}
+
+function readPackageJsonAtRef(ref) {
+  const json = execFileSync(
+    'git',
+    ['show', `${ref}:packages/nx-plugin/package.json`],
+    { encoding: 'utf8' },
+  );
+  return JSON.parse(json);
+}
+
+export function getOpenapiVersion(ref) {
+  const packageJson = ref ? readPackageJsonAtRef(ref) : readCurrentPackageJson();
+  const context = ref
+    ? `packages/nx-plugin/package.json at ref ${ref}`
+    : 'packages/nx-plugin/package.json';
+  return parseVersionFromRange(getDependencyRangeFromPackageJson(packageJson, context));
+}
+
+function setOpenapiDependency(version) {
+  const packageJson = readCurrentPackageJson();
+  const currentRange = getDependencyRangeFromPackageJson(
+    packageJson,
+    'packages/nx-plugin/package.json',
+  );
+  const nextRange = `^${version}`;
+
+  packageJson.dependencies['@hey-api/openapi-ts'] = nextRange;
+  writeFileSync(pluginPackageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
+  console.log(
+    `Updated @hey-api/openapi-ts dependency: ${currentRange} -> ${nextRange}`,
+  );
+}
+
+function main() {
+  const { ref, setVersion } = parseArgs(process.argv.slice(2));
+
+  if (setVersion) {
+    setOpenapiDependency(setVersion);
+    return;
+  }
+
+  process.stdout.write(getOpenapiVersion(ref));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}


### PR DESCRIPTION
## Summary
- automate release decisions on main (sync to upstream vs plugin patch)
- add scheduled upstream dependency sync workflow for @hey-api/openapi-ts
- update versioning script and docs for explicit sync and bump-patch flows

## Details
- release.yml now runs on push to main and manual dispatch with auto/sync/patch
- auto mode syncs plugin version exactly to upstream when upstream changed since last tag
- auto mode does a plugin patch bump when only plugin code changed
- release skips cleanly when no release is needed
- sync-openapi.yml checks npm daily and updates dependency and lockfile on main

@claude please review