### PR TITLE
[codex] fix declaration entry paths

### DIFF
--- a/packages/nx-plugin/package.json
+++ b/packages/nx-plugin/package.json
@@ -17,20 +17,20 @@
   "type": "commonjs",
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.cjs.js",
-  "types": "./dist/index.cjs.d.ts",
+  "types": "./dist/index.d.ts",
   "scripts": {
     "typecheck": "tsc --noEmit"
   },
   "exports": {
     ".": {
       "require": {
-        "types": "./dist/index.cjs.d.ts",
+        "types": "./dist/index.d.ts",
         "default": "./dist/index.cjs.js"
       }
     },
     "./plugin": {
       "require": {
-        "types": "./dist/plugin.cjs.d.ts",
+        "types": "./dist/plugin.d.ts",
         "default": "./dist/plugin.cjs.js"
       }
     },


### PR DESCRIPTION
## Summary

Update the package declaration paths to match the files emitted by the Nx/Rollup build.

## Root cause

The package manifest points TypeScript consumers at `*.cjs.d.ts` files, but the published package contains declaration files without the `.cjs` segment. For the current published package, `@seriouslag/nx-openapi-ts-plugin@0.0.41` includes `dist/index.d.ts` while `types` and `exports["."].require.types` point to the missing `dist/index.cjs.d.ts`.

The current source manifest keeps the same naming pattern for the root entry and the newer plugin subpath, while the project uses `@nx/rollup:rollup` with CJS JavaScript output names such as `index.cjs.js` / `plugin.cjs.js` and declaration output names such as `index.d.ts` / `plugin.d.ts`.

## Changes

- Point the root `types` field and root export types to `./dist/index.d.ts`.
- Point the plugin subpath export types to `./dist/plugin.d.ts`.

## Validation

- `npm pack @seriouslag/nx-openapi-ts-plugin@0.0.41 --dry-run --json` shows `dist/index.d.ts` is packed and `dist/index.cjs.d.ts` is absent.
- `npm pack --dry-run --json` from `packages/nx-plugin` confirms the manifest change is included in the package tarball.
- `git diff --check`

I attempted `pnpm install --frozen-lockfile --ignore-scripts`, but dependency installation did not complete within 10 minutes in this environment, so I could not run the full local Nx build here.