### PR TITLE
fix: add missing bugs metadata field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@seriouslag/source",
   "version": "0.0.0",
+  "bugs": {
+    "url": "https://github.com/seriouslag/openapi-ts-nx-plugin/issues"
+  },
   "license": "MIT",
   "scripts": {
     "build": "nx run-many --target=build",


### PR DESCRIPTION
Adds missing package metadata fields to `package.json`.

This allows npm tooling and consumers to correctly resolve package metadata.