### PR TITLE
test(nx-plugin): guard published manifest entry points

### DIFF
--- a/packages/nx-plugin/src/package-exports.e2e.ts
+++ b/packages/nx-plugin/src/package-exports.e2e.ts
@@ -1,0 +1,63 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { workspaceRoot } from '@nx/devkit';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Guards the published package manifest against pointing at files that the
+ * build does not emit. This previously regressed: `types` referenced
+ * `dist/index.cjs.d.ts` while the @nx/rollup build emits `dist/index.d.ts`,
+ * so the published package shipped without resolvable type definitions.
+ *
+ * Lives in the e2e suite because it asserts against build output (the e2e
+ * target depends on `build`, so `dist/` exists when this runs).
+ */
+const packageRoot = join(workspaceRoot, 'packages/nx-plugin');
+const manifest = JSON.parse(
+  readFileSync(join(packageRoot, 'package.json'), 'utf-8'),
+) as {
+  main?: string;
+  module?: string;
+  types?: string;
+  plugin?: string;
+  generators?: string;
+  executors?: string;
+  exports?: unknown;
+};
+
+/** Recursively collect every string leaf from the `exports` field. */
+function collectExportPaths(node: unknown): string[] {
+  if (typeof node === 'string') {
+    return [node];
+  }
+  if (node && typeof node === 'object') {
+    return Object.values(node).flatMap(collectExportPaths);
+  }
+  return [];
+}
+
+describe('package manifest entry points', () => {
+  const declaredPaths = [
+    ...new Set(
+      [
+        manifest.main,
+        manifest.module,
+        manifest.types,
+        manifest.plugin,
+        manifest.generators,
+        manifest.executors,
+        ...collectExportPaths(manifest.exports),
+      ].filter((value): value is string => typeof value === 'string'),
+    ),
+  ];
+
+  it('declares at least the core entry points', () => {
+    // Sanity check so the it.each below can never silently run zero cases.
+    expect(declaredPaths.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it.each(declaredPaths)('resolves "%s" to a file that exists', (relPath) => {
+    expect(existsSync(join(packageRoot, relPath))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a regression guard for the class of packaging bug fixed in #16 (originally caught by @luuhongyii in #11): the manifest pointing at files the build never emits.

A new e2e test walks **every** entry point declared in `packages/nx-plugin/package.json` — `main`, `module`, `types`, `plugin`, `generators`, `executors`, and every leaf of the `exports` map — and asserts each path resolves to a file that exists relative to the package root.

## Why

The previous bug (`types` → `dist/index.cjs.d.ts`, but the `@nx/rollup` build emits `dist/index.d.ts`) shipped the package without resolvable type definitions. Nothing in the repo — `tsc`, tests, or build — touches the packaged manifest's path resolution, so it went unnoticed. This test closes that gap for all entry points, not just `types`.

## Placement

It lives in the e2e suite (`*.e2e.ts`) because it asserts against build output, and the e2e target `dependsOn: ["build"]` so `dist/` is present when it runs.

## Verification

- Passes against the current (correct) manifest.
- **Confirmed it catches the regression:** temporarily reintroducing `types: "./dist/index.cjs.d.ts"` makes the test fail with `resolves "./dist/index.cjs.d.ts" to a file that exists`.
- typecheck + lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)