### PR TITLE
ci: publish to npm via OIDC trusted publishing (no token)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ on:
     inputs:
       tag:
         description: Tag to publish (e.g. v0.99.0). Required for manual runs.
-        required: false
+        required: true
         type: string
 
 jobs:
@@ -47,7 +47,9 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Ensure npm supports trusted publishing (>= 11.5.1)
-        run: npm install -g npm@latest
+        # Pin to the 11.x line for reproducible runs while staying on an
+        # OIDC-capable npm (trusted publishing requires npm >= 11.5.1).
+        run: npm install -g npm@11
 
       - name: Verify tag matches package version
         shell: bash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,22 +1,43 @@
 name: Publish
 
+# Publishes @seriouslag/nx-openapi-ts-plugin to npm using OIDC trusted
+# publishing — no long-lived NPM token required. The trusted publisher must be
+# configured on npmjs.com for THIS workflow file (publish.yml), because npm
+# validates the entry-point workflow that initiated the run.
 on:
   push:
     tags:
       - v*.*.*
   workflow_dispatch:
+    inputs:
+      tag:
+        description: Tag to publish (e.g. v0.99.0). Required for manual runs.
+        required: false
+        type: string
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write # needed for provenance data generation
+      id-token: write # required for OIDC trusted publishing + provenance
     timeout-minutes: 10
     steps:
+      - name: Resolve ref to publish
+        id: ref
+        shell: bash
+        run: |
+          set -euo pipefail
+          # On a tag push, github.ref_name is the tag. On a manual dispatch it
+          # is the branch, so fall back to the provided tag input.
+          REF="${{ github.event.inputs.tag || github.ref_name }}"
+          echo "ref=${REF}" >> "$GITHUB_OUTPUT"
+          echo "Publishing ref: ${REF}"
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
+          ref: ${{ steps.ref.outputs.ref }}
           fetch-depth: 0
 
       - name: Setup Node.js
@@ -25,14 +46,20 @@ jobs:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Ensure npm supports trusted publishing (>= 11.5.1)
+        run: npm install -g npm@latest
+
       - name: Verify tag matches package version
         shell: bash
         run: |
+          set -euo pipefail
           VERSION=$(node -p "require('./packages/nx-plugin/package.json').version")
           EXPECTED_TAG="v${VERSION}"
+          REF="${{ steps.ref.outputs.ref }}"
 
-          if [[ "${GITHUB_REF_NAME}" != "${EXPECTED_TAG}" ]]; then
-            echo "Ref ${GITHUB_REF_NAME} does not match package version ${EXPECTED_TAG}"
+          if [[ "${REF}" != "${EXPECTED_TAG}" ]]; then
+            echo "Ref ${REF} does not match package version ${EXPECTED_TAG}"
+            echo "For a manual run, pass the matching tag via the 'tag' input."
             exit 1
           fi
 
@@ -64,13 +91,10 @@ jobs:
       - name: Build
         run: pnpm run build
 
-      - name: Print Environment Info
-        run: npx nx report
-        shell: bash
-
-      - name: Publish packages
-        run: npx nx release publish
-        shell: bash
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
-          NPM_CONFIG_PROVENANCE: true
+      # Publish via the npm CLI (not pnpm): npm >= 11.5.1 performs the OIDC
+      # token exchange for trusted publishing. pnpm does not support OIDC yet
+      # (pnpm/pnpm#9812), so the upload must go through npm. Provenance is set
+      # explicitly because it is not reliably automatic.
+      - name: Publish to npm (OIDC trusted publishing)
+        run: npm publish --provenance --access public
+        working-directory: packages/nx-plugin


### PR DESCRIPTION
## Summary

Switches the **Publish** workflow to **npm OIDC trusted publishing**, eliminating the long-lived `NPM_ACCESS_TOKEN` that has to be rotated (and which just expired — `publish.yml` was failing with a `404 Not Found` on the registry `PUT`).

## Why the publish command changed (npm, not pnpm)

The old step ran `npx nx release publish`, which delegated to **pnpm** (the failure log showed `pnpm publish error`). pnpm **does not support OIDC trusted publishing yet** ([pnpm/pnpm#9812](https://github.com/pnpm/pnpm/issues/9812)), so the upload now goes through the **npm CLI** (≥ 11.5.1), which performs the OIDC token exchange. pnpm still does `install` + `nx build`; only the final upload moved to npm.

## Changes

- `npm publish --provenance --access public` from `packages/nx-plugin` (was `npx nx release publish`).
- `npm install -g npm@latest` to guarantee npm ≥ 11.5.1 (OIDC requires it).
- Keep `permissions: id-token: write`; **remove `NODE_AUTH_TOKEN` / `NPM_ACCESS_TOKEN`**.
- Keep provenance explicit (`--provenance`) — it isn't reliably automatic in practice.
- **Fix manual runs:** add a `tag` input + a "resolve ref" step so `workflow_dispatch` checks out and verifies the *tag* (the earlier manual run failed because `GITHUB_REF_NAME` was `main`, not `v0.99.0`).

## ⚠️ Required one-time setup (cannot be done in this PR)

On **npmjs.com → package `@seriouslag/nx-openapi-ts-plugin` → Settings → Trusted Publisher**, add GitHub Actions with:
- Organization/user: `seriouslag`
- Repository: `openapi-ts-nx-plugin`
- Workflow filename: `publish.yml`
- Allowed actions: `npm publish`

> npm validates the **entry-point** workflow, which is why `publish.yml` stays directly tag-triggered rather than being called via `workflow_call` from `release.yml` — the latter would require the trusted publisher to reference `release.yml` instead.

Once verified working, the `NPM_ACCESS_TOKEN` secret can be deleted.

## Out of scope (separate follow-up)

This fixes **auth** (no token). Two release-automation gaps remain, tracked separately:
1. `release.yml` pushes the version-bump commit directly to `main`, which the branch ruleset blocks.
2. `release.yml` tags using the default `GITHUB_TOKEN`, so the tag push does not auto-trigger `publish.yml`.

Until those are addressed, publish a release by running this workflow manually against the tag (now tokenless), e.g. `gh workflow run publish.yml --ref v0.99.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)