### PR TITLE
ci(release): auto-trigger Publish after tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: write # dispatch the Publish workflow after tagging
     timeout-minutes: 15
     steps:
       - name: Checkout repository
@@ -143,6 +144,22 @@ jobs:
           git commit -m "chore(release): ${TAG}"
           git tag "${TAG}"
           git push origin HEAD:main "${TAG}"
+
+      - name: Trigger publish workflow
+        if: ${{ steps.strategy.outputs.should_release == 'true' && steps.tag.outputs.skip_existing_tag != 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          TAG="${{ steps.tag.outputs.tag }}"
+          echo "Dispatching Publish workflow for ${TAG}"
+          # Dispatch against main so the latest publish.yml (OIDC) runs; it
+          # checks out the tag for the actual code and version. A tag push made
+          # with GITHUB_TOKEN does not trigger workflows, but workflow_dispatch
+          # is exempt from that rule, so this needs no PAT/App token.
+          gh workflow run publish.yml --ref main -f tag="${TAG}"
 
       - name: No release
         if: ${{ steps.strategy.outputs.should_release != 'true' || steps.tag.outputs.skip_existing_tag == 'true' }}


### PR DESCRIPTION
## Summary

Closes the last gap in the release pipeline so a merge to `main` flows all the way to an npm publish with **no manual steps**.

## The problem

`release.yml` creates and pushes the version tag, but a tag push made with the default `GITHUB_TOKEN` **does not trigger other workflows** (GitHub's recursion guard). So `publish.yml` (which triggers on tag push) never ran automatically — that's why `0.99.0` had to be published by hand.

## The fix

After tagging, `release.yml` now **explicitly dispatches** `publish.yml`:

```yaml
- name: Trigger publish workflow
  if: ${{ steps.strategy.outputs.should_release == 'true' && steps.tag.outputs.skip_existing_tag != 'true' }}
  env:
    GH_TOKEN: ${{ github.token }}
  run: gh workflow run publish.yml --ref main -f tag="${{ steps.tag.outputs.tag }}"
```

`★ Key detail:` `workflow_dispatch` (and `repository_dispatch`) are **exempt** from the "`GITHUB_TOKEN` events don't trigger workflows" rule. So this works with the built-in token — **no PAT or GitHub App required.** Adds the `actions: write` permission needed to call the dispatch API.

It dispatches against `main` (so the latest OIDC `publish.yml` runs) and passes the tag, which `publish.yml` checks out for the actual code and version. This also keeps `publish.yml` as the npm-validated trusted-publishing entry point.

## Result — fully automated, tokenless pipeline

```
merge to main → release.yml (version bump + tag, pushed to main)
              → dispatches publish.yml
              → publish.yml builds + npm publish via OIDC (no token)
```

Now that the branch ruleset is removed, the version-bump push to `main` also succeeds again, so the whole chain runs end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)