### PR TITLE
fix(nx-plugin): emit generator schemas & templates at expected dist paths

### DIFF
--- a/packages/nx-plugin/project.json
+++ b/packages/nx-plugin/project.json
@@ -21,29 +21,44 @@
         "rootDir": "{projectRoot}/src",
         "assets": [
           {
-            "glob": "{executors,generators,plugin}/**/*.json",
-            "input": "{projectRoot}/src",
+            "glob": "updateApi.schema.json",
+            "input": "{projectRoot}/src/executors/update-api",
             "output": "."
           },
           {
-            "glob": "files",
+            "glob": "openapiClient.schema.json",
             "input": "{projectRoot}/src/generators/openapi-client",
             "output": "."
           },
           {
-            "glob": "options",
-            "input": "{projectRoot}/src/generators/openapi-client",
+            "glob": "openapiConfig.schema.json",
+            "input": "{projectRoot}/src/generators/openapi-config",
             "output": "."
           },
           {
-            "glob": "plugins",
-            "input": "{projectRoot}/src/generators/openapi-client",
+            "glob": "plugin.schema.json",
+            "input": "{projectRoot}/src/plugin",
             "output": "."
           },
           {
-            "glob": "tests",
-            "input": "{projectRoot}/src/generators/openapi-client",
-            "output": "."
+            "glob": "**/*",
+            "input": "{projectRoot}/src/generators/openapi-client/files",
+            "output": "files"
+          },
+          {
+            "glob": "**/*",
+            "input": "{projectRoot}/src/generators/openapi-client/options",
+            "output": "options"
+          },
+          {
+            "glob": "**/*",
+            "input": "{projectRoot}/src/generators/openapi-client/plugins",
+            "output": "plugins"
+          },
+          {
+            "glob": "**/*",
+            "input": "{projectRoot}/src/generators/openapi-client/tests",
+            "output": "tests"
           }
         ]
       }

--- a/packages/nx-plugin/src/generators-manifest.e2e.ts
+++ b/packages/nx-plugin/src/generators-manifest.e2e.ts
@@ -1,0 +1,78 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { workspaceRoot } from '@nx/devkit';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Guards that the generator/executor manifests and the generator's runtime
+ * template assets actually resolve against the BUILT output.
+ *
+ * This regressed once already: the build emitted `*.schema.json` under nested
+ * dist subdirectories (and dropped the `files`/`options`/`plugins`/`tests`
+ * template dirs entirely) while `generators.json`/`executors.json` and the
+ * generator code expect them flat at the dist root — so the published plugin's
+ * generators failed to load. The unit/e2e suites run from source, where the
+ * layout differs, so they never caught it. Lives in the e2e suite because it
+ * asserts against build output (the e2e target depends on `build`).
+ */
+const packageRoot = join(workspaceRoot, 'packages/nx-plugin');
+
+function readManifest(relPath: string) {
+  return JSON.parse(readFileSync(join(packageRoot, relPath), 'utf-8'));
+}
+
+const generators = readManifest('generators.json').generators as Record<
+  string,
+  { factory: string; schema: string }
+>;
+const executors = readManifest('executors.json').executors as Record<
+  string,
+  { implementation: string; schema: string }
+>;
+
+const entries = [
+  ...Object.entries(generators).map(([name, g]) => ({
+    kind: 'generator',
+    name,
+    impl: g.factory,
+    schema: g.schema,
+  })),
+  ...Object.entries(executors).map(([name, e]) => ({
+    kind: 'executor',
+    name,
+    impl: e.implementation,
+    schema: e.schema,
+  })),
+];
+
+describe('generator/executor manifests resolve against the build output', () => {
+  it('discovers at least the known generators and executors', () => {
+    expect(entries.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it.each(entries)(
+    '$kind "$name" factory/implementation resolves to a built file',
+    ({ impl }) => {
+      expect(impl).toBeTruthy();
+      expect(existsSync(join(packageRoot, impl))).toBe(true);
+    },
+  );
+
+  it.each(entries)('$kind "$name" schema resolves to a built file', ({ schema }) => {
+    expect(schema).toBeTruthy();
+    expect(existsSync(join(packageRoot, schema))).toBe(true);
+  });
+
+  // The openapi-client generator loads templates at runtime via
+  // join(__dirname, '<dir>') — and __dirname is the dist root because the
+  // factory is bundled flat. So these asset dirs must exist and be non-empty.
+  it.each(['files', 'options', 'plugins', 'tests'])(
+    'generator template directory dist/%s exists and is non-empty',
+    (dir) => {
+      const templateDir = join(packageRoot, 'dist', dir);
+      expect(existsSync(templateDir)).toBe(true);
+      expect(readdirSync(templateDir).length).toBeGreaterThan(0);
+    },
+  );
+});


### PR DESCRIPTION
## Summary

The published plugin's **generators and executors are broken** in the entire `0.9x` line: running any of them fails because their `schema.json` and template files aren't where `generators.json`/`executors.json` and the generator code expect them.

## Root cause

The `0.9x` build assets config diverged from the working `0.0.41` flat layout in two ways:

| Asset | `0.0.41` (works) | `0.9x` (broken) | Expected by |
|---|---|---|---|
| `*.schema.json` | flat: `dist/openapiClient.schema.json` | **nested**: `dist/generators/openapi-client/openapiClient.schema.json` | `generators.json` → `./dist/openapiClient.schema.json` |
| `files`/`options`/`plugins`/`tests` templates | `dist/files/…` | **missing entirely** | generator code: `join(__dirname, 'files')` → `dist/files` |

- The `{executors,generators,plugin}/**/*.json` glob preserved the `src/` tree, nesting the schemas.
- The bare `files`/`options`/`plugins`/`tests` globs (no `/**/*`) matched nothing, so no templates were copied.

The factories (`.cjs.js`) are bundled flat by rollup, so `__dirname` is the dist root — which is why the intended layout is flat and `generators.json` already references flat paths. **`generators.json` was correct; the build was wrong.**

Why it slipped through: the unit/e2e suites run the generator from **source** (where templates sit next to the source file), so they never exercised the built dist layout.

## Fix

Rewrite the build `assets` to reproduce the flat `0.0.41` layout:
- copy each `*.schema.json` to the dist root
- copy `files`/`options`/`plugins`/`tests` via `input: <dir>, glob: "**/*"` → `dist/files`, `dist/options`, `dist/plugins`, `dist/tests`

Verified the rebuilt `dist/` matches the known-good layout (flat schemas + all 9 templates + the test templates).

## Regression guard

New e2e test `generators-manifest.e2e.ts` that:
- loads `generators.json` + `executors.json` and asserts every `factory`/`implementation`/`schema` path resolves against the built `dist/`
- asserts the generator template dirs (`dist/files|options|plugins|tests`) exist and are non-empty

Confirmed it **fails** when a schema is moved back to the old nested location. (Complements the manifest-level guard from #17, which only checked top-level package entry points — not the paths *inside* the generator manifests.)

## Verification
e2e (now 4 files / 25 tests), typecheck, lint — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)