### PR TITLE
fix(nx-plugin): load ESM-only deps via dynamic import (CJS require regression)

### DIFF
--- a/packages/nx-plugin/src/generators/openapi-client/openapiClient.ts
+++ b/packages/nx-plugin/src/generators/openapi-client/openapiClient.ts
@@ -1,7 +1,6 @@
 import { existsSync, writeFileSync } from 'node:fs';
 import { isAbsolute, join, resolve } from 'node:path';
 
-import { defaultPlugins } from '@hey-api/openapi-ts';
 import type {
   ProjectConfiguration,
   TargetConfiguration,
@@ -44,6 +43,12 @@ import {
 import { CONSTANTS } from '../../vars';
 
 const defaultTempFolder = join(process.cwd(), CONSTANTS.TMP_DIR_NAME);
+
+// @hey-api/openapi-ts is ESM-only and cannot be require()d from this CJS build,
+// so we can't import its `defaultPlugins` value at module scope (it's used in
+// the synchronous normalizeOptions). Mirror it locally; a guard test asserts
+// this stays in sync with the upstream value.
+export const defaultPlugins = ['@hey-api/typescript', '@hey-api/sdk'] as const;
 
 /**
  * Plugin configuration for the OpenAPI client generator

--- a/packages/nx-plugin/src/require-load.e2e.ts
+++ b/packages/nx-plugin/src/require-load.e2e.ts
@@ -1,0 +1,48 @@
+import { createRequire } from 'node:module';
+import { join } from 'node:path';
+
+import { workspaceRoot } from '@nx/devkit';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Guards that every built CJS entry point can actually be loaded with
+ * require(). nx loads the plugin, generators and executors from these CJS
+ * files via require, so if any of them statically require() an ESM-only
+ * dependency (e.g. @hey-api/openapi-ts, @hey-api/json-schema-ref-parser),
+ * Node throws ERR_REQUIRE_ESM / ERR_PACKAGE_PATH_NOT_EXPORTED and the plugin
+ * is unusable once published.
+ *
+ * The rest of the suite imports from source under an ESM-capable runner, so it
+ * never exercises this require() path — this test loads the real built dist.
+ * Lives in the e2e suite because it depends on build output.
+ */
+const require = createRequire(import.meta.url);
+const distRoot = join(workspaceRoot, 'packages/nx-plugin/dist');
+
+// Entry points referenced by package.json / generators.json / executors.json.
+const entryPoints = [
+  'index.cjs.js',
+  'plugin.cjs.js',
+  'openapiClient.cjs.js',
+  'openapiConfig.cjs.js',
+  'updateApi.cjs.js',
+];
+
+describe('built CJS entry points load under require()', () => {
+  it.each(entryPoints)('require("dist/%s") does not throw', (file) => {
+    expect(() => require(join(distRoot, file))).not.toThrow();
+  });
+});
+
+// We mirror @hey-api/openapi-ts's `defaultPlugins` locally because the package
+// is ESM-only and can't be require()d in the synchronous code path that needs
+// it. Guard against the upstream value drifting from our copy.
+describe('local defaultPlugins mirror stays in sync with @hey-api/openapi-ts', () => {
+  it('matches the upstream defaultPlugins value', async () => {
+    const [{ defaultPlugins: localDefaults }, openapiTs] = await Promise.all([
+      import('./generators/openapi-client/openapiClient'),
+      import('@hey-api/openapi-ts'),
+    ]);
+    expect([...localDefaults]).toEqual([...openapiTs.defaultPlugins]);
+  });
+});

--- a/packages/nx-plugin/src/utils.ts
+++ b/packages/nx-plugin/src/utils.ts
@@ -17,8 +17,7 @@ import {
   resolve,
 } from 'node:path';
 
-import { $RefParser, type JSONSchema } from '@hey-api/json-schema-ref-parser';
-import { createClient } from '@hey-api/openapi-ts';
+import type { JSONSchema } from '@hey-api/json-schema-ref-parser';
 import { logger, workspaceRoot } from '@nx/devkit';
 import { compareOpenApi } from 'api-smart-diff';
 import { format, resolveConfig } from 'prettier';
@@ -61,7 +60,12 @@ export function getPackageName(packageName: string) {
     : packageName;
 }
 
-type ConfigOptions = NonNullable<Parameters<typeof createClient>[0]>;
+// `@hey-api/openapi-ts` is ESM-only; reference its type via an import-type so
+// nothing is require()d at runtime (the value is loaded with dynamic import
+// below). See generateClientCode.
+type ConfigOptions = NonNullable<
+  Parameters<typeof import('@hey-api/openapi-ts').createClient>[0]
+>;
 type ClientConfig = Extract<
   ConfigOptions,
   {
@@ -89,6 +93,9 @@ export async function generateClientCode({
     const pluginNames = plugins.map(getPluginName);
     logger.info(`Generating client code using spec file...`);
 
+    // Dynamic import: @hey-api/openapi-ts is ESM-only and cannot be require()d
+    // from this CJS build.
+    const { createClient } = await import('@hey-api/openapi-ts');
     await createClient({
       input: specFile,
       output: outputPath,
@@ -122,6 +129,8 @@ export async function bundleAndDereferenceSpecFile({
 }) {
   try {
     logger.debug(`Bundling OpenAPI spec file ${specPath}...`);
+    // Dynamic import: @hey-api/json-schema-ref-parser is ESM-only.
+    const { $RefParser } = await import('@hey-api/json-schema-ref-parser');
     const refParser = new $RefParser();
     const dereferencedSpec = await refParser.bundle({
       pathOrUrlOrSchema: specPath,
@@ -138,6 +147,8 @@ export async function bundleAndDereferenceSpecFile({
  * Fetches an unparsed spec file
  */
 async function getSpecFile(path: string) {
+  // Dynamic import: @hey-api/json-schema-ref-parser is ESM-only.
+  const { $RefParser } = await import('@hey-api/json-schema-ref-parser');
   const refParser = new $RefParser();
   const { schema } = await refParser.parse({
     pathOrUrlOrSchema: path,


### PR DESCRIPTION
## Summary

The published plugin is **unusable at runtime**: its CJS build statically `require()`s ESM-only dependencies, so Node throws when nx loads the generators/executors.

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in .../@hey-api/openapi-ts/package.json
Error [ERR_REQUIRE_ESM] ... @hey-api/json-schema-ref-parser
```

`@hey-api/openapi-ts` and `@hey-api/json-schema-ref-parser` are both `"type": "module"` with import-only exports. `0.0.41` worked because those deps were still CJS-compatible; the `0.9x` versions went ESM-only.

## Fix

Load the ESM-only deps with dynamic `await import()` — **the pattern already used in this codebase for `latest-version`**, which rollup preserves in CJS output (so it's proven to work here):

- **`utils.ts`** — `createClient` and `$RefParser` are imported dynamically inside their (already-async) functions. The `createClient` *type* is referenced via `typeof import('@hey-api/openapi-ts').createClient`, which is fully erased at build time (no runtime `require`).
- **`openapiClient.ts`** — `defaultPlugins` is needed in the **synchronous** `normalizeOptions`, so dynamic import isn't possible there. It's mirrored as a local constant (`['@hey-api/typescript','@hey-api/sdk']`) — a stable 2-element list the code already hard-couples to (it special-cases the SDK plugin for `asClass`).

Bundling was rejected: `@hey-api/openapi-ts` loads its own plugins/clients at runtime and can't be safely bundled. Full ESM was rejected to avoid nx plugin-loading compatibility risk.

## Guards (test-first)

Added `require-load.e2e.ts`, written and validated to **fail before the fix** (3 of 5 entry points threw `ERR_PACKAGE_PATH_NOT_EXPORTED`):
- `require()`s every built CJS entry point (`index`, `plugin`, `openapiClient`, `openapiConfig`, `updateApi`) and asserts it loads — the whole suite otherwise runs from source/ESM and never exercised the CJS `require` path.
- asserts the local `defaultPlugins` mirror matches `@hey-api/openapi-ts`'s actual value (drift guard).

## Verification
typecheck · lint · 110 unit tests · 31 e2e (incl. the new 6-test require-load guard, and the real-codegen e2e which now exercises `createClient` through the dynamic import) — all green.

Merging auto-publishes `0.99.3` — the first genuinely working release of the `0.9x` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)