### PR TITLE
feat(nx-plugin): update-api reads openapi-ts.config for config-only settings

### DIFF
--- a/packages/nx-plugin/src/executors/update-api/updateApi.ts
+++ b/packages/nx-plugin/src/executors/update-api/updateApi.ts
@@ -15,6 +15,7 @@ import {
   bundleAndDereferenceSpecFile,
   cleanupTempFolder,
   compareSpecs,
+  findOpenApiConfigFile,
   formatFiles,
   formatStringFromFilePath,
   generateClientCode,
@@ -222,9 +223,11 @@ const runExecutor: PromiseExecutor<UpdateApiExecutorSchema> = async (
       await makeDir(absoluteGeneratedTempDir);
     }
 
-    // Generate new client code
+    // Generate new client code. Pass the project's openapi-ts.config.* (if
+    // present) so config-only settings such as parser.hooks are honoured.
     await generateClientCode({
       clientType: options.client,
+      configFile: findOpenApiConfigFile(join(process.cwd(), projectRoot)),
       outputPath: generatedTempDir,
       plugins: options.plugins,
       specFile: tempSpecPath,

--- a/packages/nx-plugin/src/utils.spec.ts
+++ b/packages/nx-plugin/src/utils.spec.ts
@@ -9,6 +9,7 @@ import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   bundleAndDereferenceSpecFile,
   cleanupTempFolder,
+  findOpenApiConfigFile,
   generateClientCode,
   generateClientCommand,
   getBaseTsConfigPath,
@@ -154,6 +155,66 @@ describe('utils', () => {
         }),
       ).rejects.toThrow('Command failed');
     });
+
+    it('should pass configFile to createClient when provided', async () => {
+      await expect(
+        generateClientCode({
+          clientType: '@hey-api/client-fetch',
+          configFile: '/project/openapi-ts.config.mts',
+          outputPath: './src/generated',
+          plugins: ['@hey-api/typescript', '@hey-api/sdk'],
+          specFile: './api/spec.yaml',
+        }),
+      ).resolves.not.toThrow();
+
+      expect(createClient).toHaveBeenCalledWith({
+        configFile: '/project/openapi-ts.config.mts',
+        input: './api/spec.yaml',
+        output: './src/generated',
+        plugins: [
+          '@hey-api/client-fetch',
+          '@hey-api/typescript',
+          '@hey-api/sdk',
+        ],
+      });
+    });
+
+    it('should not pass configFile to createClient when omitted', async () => {
+      await generateClientCode({
+        clientType: '@hey-api/client-fetch',
+        outputPath: './src/generated',
+        plugins: ['@hey-api/typescript', '@hey-api/sdk'],
+        specFile: './api/spec.yaml',
+      });
+
+      const lastCall = vi.mocked(createClient).mock.calls.at(-1)?.[0];
+      expect(lastCall).not.toHaveProperty('configFile');
+    });
+  });
+
+  describe('findOpenApiConfigFile', () => {
+    it('returns the first matching config file path', () => {
+      vi.mocked(existsSync).mockImplementation(
+        (p) => p === join('/project', 'openapi-ts.config.ts'),
+      );
+      expect(findOpenApiConfigFile('/project')).toBe(
+        join('/project', 'openapi-ts.config.ts'),
+      );
+    });
+
+    it('resolves .mts when .ts is absent', () => {
+      vi.mocked(existsSync).mockImplementation(
+        (p) => p === join('/project', 'openapi-ts.config.mts'),
+      );
+      expect(findOpenApiConfigFile('/project')).toBe(
+        join('/project', 'openapi-ts.config.mts'),
+      );
+    });
+
+    it('returns undefined when no config file exists', () => {
+      vi.mocked(existsSync).mockReturnValue(false);
+      expect(findOpenApiConfigFile('/project')).toBeUndefined();
+    });
   });
 
   describe('bundleAndDereferenceSpecFile', () => {
@@ -192,7 +253,10 @@ paths:
     });
 
     it('should throw error when bundle command fails', async () => {
-      const tempSpecFile = join(process.cwd(), `temp-spec-${randomUUID()}.yaml`);
+      const tempSpecFile = join(
+        process.cwd(),
+        `temp-spec-${randomUUID()}.yaml`,
+      );
 
       await expect(() =>
         bundleAndDereferenceSpecFile({
@@ -258,7 +322,9 @@ paths:
 
         await cleanupTempFolder(tempFolder);
 
-        await expect(lstat(join(process.cwd(), 'plugin-tmp'))).rejects.toThrow();
+        await expect(
+          lstat(join(process.cwd(), 'plugin-tmp')),
+        ).rejects.toThrow();
       } finally {
         process.chdir(originalCwd);
         await rm(sandbox, { force: true, recursive: true });

--- a/packages/nx-plugin/src/utils.ts
+++ b/packages/nx-plugin/src/utils.ts
@@ -74,16 +74,45 @@ type ClientConfig = Extract<
 >;
 
 /**
- * Generates the client code using the spec file
+ * Supported `openapi-ts.config.*` file extensions, in resolution order.
+ */
+const OPENAPI_CONFIG_EXTENSIONS = ['ts', 'mts', 'cts', 'mjs', 'cjs', 'js'];
+
+/**
+ * Locates a project's `openapi-ts.config.*` file, if one exists. Returns the
+ * absolute path so `@hey-api/openapi-ts` can load it via its `configFile`
+ * option. Returns `undefined` when no config file is present.
+ */
+export function findOpenApiConfigFile(projectRoot: string): string | undefined {
+  for (const extension of OPENAPI_CONFIG_EXTENSIONS) {
+    const candidate = join(projectRoot, `openapi-ts.config.${extension}`);
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Generates the client code using the spec file.
+ *
+ * When the project has an `openapi-ts.config.*` file, its path is passed to
+ * `createClient` so settings that have no executor option — most importantly
+ * `parser.hooks` (e.g. classifying a POST endpoint as a query) and `output`
+ * tweaks — are honoured. The executor-derived `input`, `output`, and `plugins`
+ * still win, because `@hey-api/openapi-ts` deep-merges the passed config over
+ * the loaded file (`mergeConfigs(fileConfig, userConfig)`).
  */
 export async function generateClientCode({
   clientType,
+  configFile,
   outputPath,
   plugins,
   specFile,
   watch,
 }: {
   clientType: string;
+  configFile?: string;
   outputPath: string;
   plugins: Plugin[];
   specFile: string;
@@ -92,11 +121,15 @@ export async function generateClientCode({
   try {
     const pluginNames = plugins.map(getPluginName);
     logger.info(`Generating client code using spec file...`);
+    if (configFile) {
+      logger.debug(`Using openapi-ts config file: ${configFile}`);
+    }
 
     // Dynamic import: @hey-api/openapi-ts is ESM-only and cannot be require()d
     // from this CJS build.
     const { createClient } = await import('@hey-api/openapi-ts');
     await createClient({
+      ...(configFile ? { configFile } : {}),
       input: specFile,
       output: outputPath,
       plugins: [clientType, ...pluginNames] as ClientConfig['plugins'],

--- a/packages/nx-plugin/src/utils.ts
+++ b/packages/nx-plugin/src/utils.ts
@@ -84,8 +84,9 @@ const OPENAPI_CONFIG_EXTENSIONS = ['ts', 'mts', 'cts', 'mjs', 'cjs', 'js'];
  * option. Returns `undefined` when no config file is present.
  */
 export function findOpenApiConfigFile(projectRoot: string): string | undefined {
+  const absoluteRoot = resolve(projectRoot);
   for (const extension of OPENAPI_CONFIG_EXTENSIONS) {
-    const candidate = join(projectRoot, `openapi-ts.config.${extension}`);
+    const candidate = join(absoluteRoot, `openapi-ts.config.${extension}`);
     if (existsSync(candidate)) {
       return candidate;
     }
@@ -130,10 +131,10 @@ export async function generateClientCode({
     const { createClient } = await import('@hey-api/openapi-ts');
     await createClient({
       ...(configFile ? { configFile } : {}),
+      ...(watch !== undefined ? { watch } : {}),
       input: specFile,
       output: outputPath,
       plugins: [clientType, ...pluginNames] as ClientConfig['plugins'],
-      watch,
     });
     logger.info(`Generated client code successfully.`);
   } catch (error) {


### PR DESCRIPTION
## Summary

The `update-api` executor built its `@hey-api/openapi-ts` config **purely from executor options** (`createClient({ input, output, plugins })`), ignoring any `openapi-ts.config.*` file in the project. Settings that have **no executor option** — most importantly `parser.hooks` (e.g. classifying a POST endpoint as a query so query options are generated) and `output` tweaks — were silently dropped on every `build`/`typecheck` run.

This is surprising because the `generateApi` target (which runs the CLI with `-f openapi-ts.config.mts`) **does** honour those settings, so the two code paths produced **different generated output** for the same project. Since `build`/`typecheck` `dependsOn: ['updateApi']`, the executor's output is what actually ships and what CI verifies.

### The fix

`generateClientCode` now accepts an optional `configFile`, and `update-api` resolves the project's `openapi-ts.config.*` (via a new `findOpenApiConfigFile` helper) and passes it through to `createClient`. The executor-derived `input`/`output`/`plugins` still take precedence, because `@hey-api/openapi-ts` deep-merges the passed config over the loaded file (`mergeConfigs(fileConfig, userConfig)`) — so nothing about existing behaviour changes for projects that don't rely on config-only settings.

Concretely, this makes a config like the following work under `updateApi`, not just `generateApi`:

```ts
// openapi-ts.config.mts
export default defineConfig({
  // ...
  parser: {
    hooks: {
      operations: {
        // POST batch/search endpoints consumed as queries
        isQuery: (op) => op.method === 'post' && op.path === '/v1/companies/search' ? true : undefined,
      },
    },
  },
});
```

## Test plan

- [x] `findOpenApiConfigFile` resolves `.ts`/`.mts` in order and returns `undefined` when absent (new unit tests)
- [x] `generateClientCode` passes `configFile` to `createClient` when provided, and omits it otherwise (new unit tests)
- [x] Existing `utils` and `update-api` executor suites still pass (60 + 7 tests green)
- [x] `tsc -p tsconfig.lib.json --noEmit` clean; eslint + prettier clean on changed files
- [x] Verified end-to-end against a real consumer repo: with this change, `updateApi` regenerates `getBuyersOptions`/`getSellersOptions` (POST-as-query) from the project's `openapi-ts.config.mts` `isQuery` hook, which the unpatched executor dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)