### PR TITLE
test(nx-plugin): e2e test that generateApi actually invokes the openapi-ts binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '24'
+          node-version: ${{ matrix.node-version }}
 
       - uses: pnpm/action-setup@v4
         name: Install pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,16 @@ jobs:
 
           echo "skip_existing_tag=false" >> $GITHUB_OUTPUT
 
+      - name: Generate changelog entry
+        if: ${{ steps.strategy.outputs.should_release == 'true' && steps.tag.outputs.skip_existing_tag != 'true' }}
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: cliff.toml
+          args: --tag ${{ steps.tag.outputs.tag }} --unreleased --prepend CHANGELOG.md
+        env:
+          OUTPUT: CHANGELOG.md
+          GITHUB_REPO: ${{ github.repository }}
+
       - name: Create release artifacts and push
         if: ${{ steps.strategy.outputs.should_release == 'true' && steps.tag.outputs.skip_existing_tag != 'true' }}
         shell: bash
@@ -131,16 +141,23 @@ jobs:
 
           TAG="${{ steps.tag.outputs.tag }}"
 
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
           if git diff --quiet -- packages/nx-plugin/package.json; then
-            echo "No version change detected in packages/nx-plugin/package.json. Tagging current HEAD."
+            echo "No version change detected in packages/nx-plugin/package.json. Committing changelog only."
+            git add CHANGELOG.md
+            if git diff --quiet --cached; then
+              echo "No staged changes. Tagging current HEAD without commit."
+            else
+              git commit -m "chore(release): ${TAG}"
+            fi
             git tag "${TAG}"
-            git push origin "${TAG}"
+            git push origin HEAD:main "${TAG}"
             exit 0
           fi
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add packages/nx-plugin/package.json
+          git add packages/nx-plugin/package.json CHANGELOG.md
           git commit -m "chore(release): ${TAG}"
           git tag "${TAG}"
           git push origin HEAD:main "${TAG}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- Changelog is auto-generated from v0.99.3 onwards via git-cliff. For history prior to that, see the git log. -->
+
 ## 0.0.3 (2025-04-15)
 
 ### 🚀 Features

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,162 @@
+# CLAUDE.md — Project guide for AI assistants
+
+This file captures the non-obvious rules and invariants for this repo. Read it before making any commits, version changes, or CI modifications.
+
+---
+
+## Repo layout
+
+```
+/
+├── packages/nx-plugin/   # @seriouslag/nx-openapi-ts-plugin — the only published package
+├── apps/test-plugin/     # React playground (not published)
+├── .github/workflows/    # CI, release, publish, sync pipelines
+├── cliff.toml            # git-cliff changelog config
+└── renovate.json         # Renovate dependency update config
+```
+
+---
+
+## Commit conventions
+
+All commits must follow [Conventional Commits](https://www.conventionalcommits.org/). The `cliff.toml` config parses these to generate `CHANGELOG.md` on every release.
+
+**Format:** `type(scope): description`
+
+| Type       | Use for                                |
+| ---------- | -------------------------------------- |
+| `feat`     | New user-facing feature                |
+| `fix`      | Bug fix                                |
+| `docs`     | Documentation only                     |
+| `refactor` | Code change with no behavior change    |
+| `test`     | Adding or fixing tests                 |
+| `ci`       | CI workflow changes                    |
+| `chore`    | Maintenance (dep bumps, tooling, etc.) |
+| `perf`     | Performance improvement                |
+
+**Scope** should be the affected area: `nx-plugin`, `release`, `deps`, etc.
+
+**Breaking changes:** append `!` after the type/scope — e.g. `feat(nx-plugin)!: rename option` — or add a `BREAKING CHANGE:` footer. cliff groups these prominently in the changelog.
+
+### Reserved commit patterns — never write these manually
+
+| Pattern                                           | Owner                  | Why                                                                     |
+| ------------------------------------------------- | ---------------------- | ----------------------------------------------------------------------- |
+| `chore(release): vX.Y.Z`                          | `release.yml` bot      | Triggers the infinite-loop guard; writing it manually skips the release |
+| `chore(deps): bump @hey-api/openapi-ts to ^X.Y.Z` | `sync-openapi.yml` bot | Version-mirror logic runs only in that workflow                         |
+
+Writing either pattern manually will either silently skip a release (the `release.yml` guard filters on this prefix) or produce a version that violates the policy check and breaks CI.
+
+---
+
+## Versioning — the mirror constraint
+
+**The plugin version must mirror `@hey-api/openapi-ts`:** `major.minor` must match, and `patch` must be ≥ the openapi-ts patch.
+
+Examples of valid versions when openapi-ts is `0.99.0`:
+
+- `0.99.0` ✅
+- `0.99.3` ✅ (plugin-only patch releases)
+- `0.99` ✅
+- `1.0.0` ❌ (major mismatch)
+- `0.98.5` ❌ (minor mismatch)
+
+**Never manually edit `packages/nx-plugin/package.json` `version`.** The release pipeline owns this field. Use the scripts instead:
+
+```bash
+# Check whether the current version satisfies the policy
+pnpm run version:check:nx-plugin
+
+# Sync the plugin version to match the current openapi-ts dep exactly
+pnpm run version:sync:nx-plugin
+
+# Bump the plugin patch (for plugin-only changes when openapi-ts hasn't changed)
+pnpm run version:bump:nx-plugin
+```
+
+The version check runs on every CI push and every publish. A misaligned version will fail CI.
+
+---
+
+## Release pipeline
+
+```
+push to main (packages/nx-plugin/**)
+  └─► release.yml
+        ├─ determines mode: sync | patch | none
+        ├─ bumps packages/nx-plugin/package.json (if needed)
+        ├─ runs git-cliff → prepends entry to CHANGELOG.md
+        ├─ commits "chore(release): vX.Y.Z" + pushes tag
+        └─► dispatches publish.yml
+              └─ npm publish --provenance (OIDC, no token)
+```
+
+Key facts:
+
+- `release.yml` pushes directly to `main` (no PR). Branch protection must allow the `github-actions[bot]`.
+- A tag push made with `GITHUB_TOKEN` does not trigger workflows — that is why `publish.yml` is dispatched manually via `gh workflow run`.
+- Preview releases are triggered by a `/preview` comment on a PR (requires write permission).
+
+---
+
+## Development workflow
+
+```bash
+# Install
+pnpm install
+
+# Build all
+pnpm run build
+
+# Lint (auto-fix on pre-commit via lefthook)
+pnpm run lint
+
+# Typecheck
+pnpm run typecheck
+
+# Unit tests
+pnpm run test
+
+# E2e tests (requires build output)
+pnpm nx run @seriouslag/nx-openapi-ts-plugin:e2e
+```
+
+Pre-commit hooks (lefthook) run ESLint with auto-fix and Prettier on staged files automatically.
+
+---
+
+## Test structure
+
+| Suite | Config                | Pattern                   | Notes                                                                   |
+| ----- | --------------------- | ------------------------- | ----------------------------------------------------------------------- |
+| Unit  | `vite.config.mts`     | `src/**/*.{spec,test}.ts` | Mocks `@nx/devkit`, `createClient`, etc.                                |
+| E2e   | `vite.e2e.config.mts` | `src/**/*.e2e.ts`         | Uses real build output and real codegen. Requires `build` to run first. |
+
+E2e tests that run real codegen (`openapiClient.codegen.e2e.ts`, `swagger-codegen.e2e.ts`) use `mkdtempSync` temp directories and clean up in `afterEach`. They do not mock `@hey-api/openapi-ts`.
+
+No coverage threshold is currently enforced, but coverage is collected via `@vitest/coverage-v8`.
+
+---
+
+## Key integration points to watch
+
+These dependencies have unusual constraints or update risks:
+
+| Dep                                                   | Risk                                      | Notes                                                                                                                                                         |
+| ----------------------------------------------------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@hey-api/openapi-ts`                                 | Version-mirror constraint                 | Managed by `sync-openapi.yml`. Do not let Renovate touch it (excluded in `renovate.json`).                                                                    |
+| `@nx/devkit`                                          | Generator API surface                     | Nx major versions may rename or remove tree/generator APIs. Pin upgrades and run full e2e suite after.                                                        |
+| `swagger2openapi`                                     | Potentially abandoned (last release 2022) | Used only in `compareSpecs` for diff detection. Guarded by `utils.compare-spec.spec.ts`.                                                                      |
+| `@hey-api/json-schema-ref-parser`                     | ESM-only                                  | Loaded via dynamic `import()` in CJS build. Do not change to a static `require()`.                                                                            |
+| `latest-version`                                      | ESM-only                                  | Same constraint as above.                                                                                                                                     |
+| EJS templates in `generators/openapi-client/files/**` | Silent breakage                           | These are copied verbatim at generation time. Changes to `@nx/devkit` `generateFiles` API or template variable names fail at generation time, not build time. |
+
+---
+
+## Changelog
+
+`CHANGELOG.md` is auto-generated from `v0.99.3` onwards. git-cliff reads conventional commits between the last tag and the new tag and prepends an entry on every release. The `cliff.toml` at the repo root controls grouping and formatting.
+
+- Do not hand-edit `CHANGELOG.md` above the `<!-- ... -->` comment line.
+- Do not add entries manually — they will be overwritten on the next release.
+- History before `v0.99.3` was maintained manually and stops at `0.0.3`.

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,48 @@
+[changelog]
+header = "# Changelog\n\n"
+body = """
+{% if version %}\
+    ## {{ version | trim_start_matches(pat="v") }} ({{ timestamp | date(format="%Y-%m-%d") }})
+{% else %}\
+    ## [unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | striptags | trim | upper_first }}
+
+    {% for commit in commits %}\
+        - {% if commit.scope %}**{{ commit.scope }}:** {% endif %}\
+          {{ commit.message | upper_first }}\
+          ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/seriouslag/openapi-ts-nx-plugin/commit/{{ commit.id }}))\
+    {% endfor %}
+{% endfor %}\n
+"""
+trim = true
+footer = ""
+postprocessors = []
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+commit_preprocessors = [
+  { pattern = "Merge pull request #(\\d+).*", replace = "" },
+]
+commit_parsers = [
+  { message = "^feat", group = "🚀 Features" },
+  { message = "^fix", group = "🐛 Bug Fixes" },
+  { message = "^docs", group = "📚 Documentation" },
+  { message = "^perf", group = "⚡ Performance" },
+  { message = "^refactor", group = "♻️ Refactoring" },
+  { message = "^test", group = "🧪 Testing" },
+  { message = "^ci", group = "👷 CI" },
+  { message = "^chore\\(release\\)", skip = true },
+  { message = "^chore\\(deps\\)", group = "⬆️ Dependencies" },
+  { message = "^chore", group = "🔧 Miscellaneous" },
+]
+protect_breaking_commits = false
+filter_commits = true
+tag_pattern = "v[0-9]*"
+skip_tags = ""
+ignore_tags = ""
+topo_order = false
+sort_commits = "oldest"

--- a/packages/nx-plugin/src/generators/openapi-client/README.md
+++ b/packages/nx-plugin/src/generators/openapi-client/README.md
@@ -14,17 +14,24 @@ nx generate @seriouslag/nx-openapi-ts-plugin:openapi-client
 
 ## Options
 
-| Option      | Description                                       | Required | Default                 | Type                        |
-| ----------- | ------------------------------------------------- | -------- | ----------------------- | --------------------------- |
-| `name`      | Library name                                      | Yes      | -                       | string                      |
-| `scope`     | Scope of the project                              | Yes      | -                       | string                      |
-| `spec`      | Path to the OpenAPI spec file (URL or local path) | Yes      | -                       | string                      |
-| `client`    | Type of client to generate                        | No       | `@hey-api/client-fetch` | string                      |
-| `directory` | Directory where the library will be created       | No       | `libs`                  | string                      |
-| `tags`      | Add tags to the library (comma-separated)         | No       | `api,openapi`           | string[]                    |
-| `plugins`   | Additional plugins for client                     | No       | []                      | string[]                    |
-| `test`      | Tests to generate                                 | No       | `none`                  | 'none', 'vitest', or 'jest' |
-| `private`   | Whether to make the generated package private     | No       | `true`                  | boolean                     |
+| Option              | Description                                                                                                                                                                                                | Required | Default                 | Type                        |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ----------------------- | --------------------------- |
+| `name`              | Library name                                                                                                                                                                                               | Yes      | -                       | string                      |
+| `scope`             | Scope of the project (e.g. `@my-org`)                                                                                                                                                                      | Yes      | -                       | string                      |
+| `spec`              | Path to the OpenAPI spec file (URL or local path). Swagger 2.0 and OpenAPI 3.x supported.                                                                                                                  | Yes      | -                       | string                      |
+| `client`            | Type of client to generate                                                                                                                                                                                 | No       | `@hey-api/client-fetch` | string                      |
+| `directory`         | Directory where the library will be created                                                                                                                                                                | No       | `libs`                  | string                      |
+| `tags`              | Add tags to the library (comma-separated)                                                                                                                                                                  | No       | `api,openapi`           | string[]                    |
+| `plugins`           | Additional `@hey-api/openapi-ts` plugins to enable (e.g. `@hey-api/schemas`, `@tanstack/react-query`, `zod`)                                                                                               | No       | `[]`                    | string[]                    |
+| `test`              | Test runner to scaffold                                                                                                                                                                                    | No       | `none`                  | `none`, `vitest`, or `jest` |
+| `private`           | Whether to make the generated package private                                                                                                                                                              | No       | `true`                  | boolean                     |
+| `useInferredTasks`  | Use Nx inferred tasks instead of explicit targets. When `true`, the generator creates minimal project config and relies on the Nx plugin to infer targets from `openapi-ts.config.*`                       | No       | `true`                  | boolean                     |
+| `projectReferences` | Add TypeScript project references to the generated project                                                                                                                                                 | No       | `true`                  | boolean                     |
+| `baseTsConfigName`  | Name of the base tsconfig file that contains compiler paths (e.g. `tsconfig.base.json`). Use when the base tsconfig is at the workspace root. Cannot be used together with a file-path `baseTsConfigPath`. | No       | -                       | string                      |
+| `baseTsConfigPath`  | Path to the base tsconfig file or directory. If a directory and `baseTsConfigName` is set, the name is appended. If a file path, do not also set `baseTsConfigName`.                                       | No       | -                       | string                      |
+| `serveCmdName`      | Name of the Nx target used to serve implicit dependencies while watching for changes                                                                                                                       | No       | `serve`                 | string                      |
+
+> **Note:** `asClass` appears in the schema but is not yet functional.
 
 ## Examples
 

--- a/packages/nx-plugin/src/generators/openapi-client/swagger-codegen.e2e.ts
+++ b/packages/nx-plugin/src/generators/openapi-client/swagger-codegen.e2e.ts
@@ -1,0 +1,133 @@
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { convertSwaggerToOpenApi } from '../../utils';
+import { generateClientCode } from '../../utils';
+
+// Minimal Swagger 2.0 spec with one operation and one schema — enough to
+// assert that both the type and the SDK operation appear in generated output.
+const SWAGGER_2_SPEC = `
+swagger: "2.0"
+info:
+  title: Swagger Codegen E2E API
+  version: "1.0.0"
+host: api.example.com
+basePath: /v1
+schemes:
+  - https
+paths:
+  /users/{userId}:
+    get:
+      operationId: getUserById
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: "#/definitions/User"
+definitions:
+  User:
+    type: object
+    properties:
+      id:
+        type: string
+      name:
+        type: string
+`;
+
+/**
+ * Guards against @hey-api/openapi-ts dropping Swagger 2.0 input support and
+ * against swagger2openapi breaking its conversion API. Both are dependencies
+ * with long release gaps that could silently break the Swagger 2.0 path.
+ */
+describe('Swagger 2.0 integration', () => {
+  const tempRoots: string[] = [];
+
+  afterEach(() => {
+    while (tempRoots.length > 0) {
+      const root = tempRoots.pop();
+      if (root) rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it('convertSwaggerToOpenApi produces a valid OpenAPI 3.x object', async () => {
+    const spec = {
+      swagger: '2.0',
+      info: { title: 'Test', version: '1.0.0' },
+      host: 'api.example.com',
+      basePath: '/v1',
+      paths: {
+        '/users': {
+          get: {
+            operationId: 'listUsers',
+            responses: { '200': { description: 'OK' } },
+          },
+        },
+      },
+    };
+
+    const result = await convertSwaggerToOpenApi(spec as any);
+
+    expect(result).toHaveProperty('openapi');
+    expect((result as any).openapi).toMatch(/^3\./);
+    expect(result).toHaveProperty('paths./users');
+  });
+
+  it('generates a real fetch client from a Swagger 2.0 spec file', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'nx-openapi-swagger-e2e-'));
+    tempRoots.push(root);
+
+    const specFile = join(root, 'swagger.yaml');
+    writeFileSync(specFile, SWAGGER_2_SPEC);
+    const outputPath = join(root, 'generated');
+
+    await generateClientCode({
+      clientType: '@hey-api/client-fetch',
+      outputPath,
+      plugins: ['@hey-api/typescript', '@hey-api/sdk'],
+      specFile,
+    });
+
+    expect(existsSync(join(outputPath, 'index.ts'))).toBe(true);
+    expect(existsSync(join(outputPath, 'types.gen.ts'))).toBe(true);
+    expect(existsSync(join(outputPath, 'sdk.gen.ts'))).toBe(true);
+
+    const types = readFileSync(join(outputPath, 'types.gen.ts'), 'utf-8');
+    expect(types).toContain('User');
+
+    const sdk = readFileSync(join(outputPath, 'sdk.gen.ts'), 'utf-8');
+    expect(sdk).toContain('getUserById');
+  });
+
+  it('generates a client with @hey-api/schemas plugin', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'nx-openapi-schemas-e2e-'));
+    tempRoots.push(root);
+
+    const specFile = join(root, 'swagger.yaml');
+    writeFileSync(specFile, SWAGGER_2_SPEC);
+    const outputPath = join(root, 'generated');
+
+    await generateClientCode({
+      clientType: '@hey-api/client-fetch',
+      outputPath,
+      plugins: ['@hey-api/typescript', '@hey-api/sdk', '@hey-api/schemas'],
+      specFile,
+    });
+
+    expect(existsSync(join(outputPath, 'index.ts'))).toBe(true);
+    expect(existsSync(join(outputPath, 'schemas.gen.ts'))).toBe(true);
+  });
+});

--- a/packages/nx-plugin/src/plugin/plugin.e2e.ts
+++ b/packages/nx-plugin/src/plugin/plugin.e2e.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execFileSync } from 'node:child_process';
@@ -118,6 +118,55 @@ describe('plugin inferred e2e', () => {
       );
     },
   );
+
+  it('generateApi target runs the openapi-ts binary and produces generated files', () => {
+    const root = writeWorkspace({ extension: 'cjs' });
+    tempRoots.push(root);
+
+    // Write the spec file the config references (input: './api/spec.yaml')
+    const specDir = join(root, 'packages/sample/api');
+    mkdirSync(specDir, { recursive: true });
+    writeFileSync(
+      join(specDir, 'spec.yaml'),
+      [
+        'openapi: "3.0.0"',
+        'info:',
+        '  title: E2E Binary Test API',
+        '  version: "1.0.0"',
+        'paths:',
+        '  /items:',
+        '    get:',
+        '      operationId: listItems',
+        '      responses:',
+        '        "200":',
+        '          description: OK',
+      ].join('\n'),
+    );
+
+    // Run the inferred generateApi target. The temp workspace has no
+    // node_modules, so we extend PATH to include the monorepo's bin dirs —
+    // matching what a real user project looks like after `npm install`.
+    // NX_DAEMON=false prevents daemon startup overhead in test environments.
+    execFileSync('node', [nxBin, 'run', '@tmp/inferred-e2e:generateApi'], {
+      cwd: root,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: {
+        ...process.env,
+        NX_DAEMON: 'false',
+        PATH: [
+          join(workspaceRoot, 'node_modules/.bin'),
+          join(workspaceRoot, 'packages/nx-plugin/node_modules/.bin'),
+          process.env.PATH ?? '',
+        ].join(':'),
+      },
+    });
+
+    const generatedDir = join(root, 'packages/sample/src/generated');
+    expect(existsSync(join(generatedDir, 'index.ts'))).toBe(true);
+    expect(existsSync(join(generatedDir, 'types.gen.ts'))).toBe(true);
+    expect(existsSync(join(generatedDir, 'sdk.gen.ts'))).toBe(true);
+  });
 
   it('applies custom inferred target names from plugin options', () => {
     const root = writeWorkspace({

--- a/packages/nx-plugin/src/plugin/plugin.spec.ts
+++ b/packages/nx-plugin/src/plugin/plugin.spec.ts
@@ -89,8 +89,45 @@ describe('plugin createNodesV2', () => {
       expect(updateApiTarget?.outputs).toContain(
         '{projectRoot}/src/generated-custom',
       );
+
+      // Uses the installed binary directly — not npx — so pnpm strict hoisting
+      // does not cause a fresh download instead of using the pre-installed package.
+      expect(generateApiTarget?.options?.command).toBe('openapi-ts');
+      expect(generateApiTarget?.options?.command).not.toMatch(/^npx/);
     },
   );
+
+  it('remote spec hash input uses xcurl binary directly, not npx', async () => {
+    const { tempProjectRoot } = writeConfigFixture('ts');
+    const root = tempProjectRoot.split('/libs/')[0] || tempProjectRoot;
+    createdRoots.push(root);
+
+    const absoluteProjectRoot = join(workspaceRoot, tempProjectRoot);
+    const remoteConfigPath = join(absoluteProjectRoot, 'openapi-ts.config.ts');
+    writeFileSync(
+      remoteConfigPath,
+      `export default {
+  input: { path: 'https://example.com/api/openapi.yaml' },
+  output: { path: 'src/generated' },
+  plugins: ['@hey-api/client-fetch'],
+}`,
+    );
+    const configFile = `${tempProjectRoot}/openapi-ts.config.ts`;
+
+    const [, createNodes] = createNodesV2;
+    const result = await createNodes([configFile], {}, getCreateNodesContext());
+    const [, createNodesResult] = result[0];
+    const updateApiTarget =
+      createNodesResult.projects?.[tempProjectRoot]?.targets?.updateApi;
+
+    const runtimeInput = updateApiTarget?.inputs?.find(
+      (i: any) => typeof i === 'object' && 'runtime' in i,
+    ) as { runtime: string } | undefined;
+
+    expect(runtimeInput).toBeDefined();
+    expect(runtimeInput?.runtime).toContain('xcurl');
+    expect(runtimeInput?.runtime).not.toContain('npx');
+  });
 
   it('should honor custom buildTargetName for inferred updateApi dependsOn', async () => {
     const { configFile, tempProjectRoot } = writeConfigFixture('ts');

--- a/packages/nx-plugin/src/plugin/plugin.ts
+++ b/packages/nx-plugin/src/plugin/plugin.ts
@@ -266,7 +266,7 @@ function createOpenApiTargets(
   } else {
     // For remote specs, add a runtime hash check
     const apiHash = {
-      runtime: `npx node -e "console.log(require('crypto').createHash('sha256').update(process.argv[1]).digest('hex'))" "$(npx -y xcurl -s ${input})"`,
+      runtime: `node -e "console.log(require('crypto').createHash('sha256').update(process.argv[1]).digest('hex'))" "$(xcurl -s ${input})"`,
     };
     updateInputs.push(apiHash);
   }
@@ -278,7 +278,7 @@ function createOpenApiTargets(
     executor: 'nx:run-commands',
     inputs: baseInputs,
     options: {
-      command: `npx @hey-api/openapi-ts`,
+      command: `openapi-ts`,
       cwd: '{projectRoot}',
     },
     outputs: [`{projectRoot}/${output}`],

--- a/packages/nx-plugin/src/utils.spec.ts
+++ b/packages/nx-plugin/src/utils.spec.ts
@@ -63,7 +63,7 @@ describe('utils', () => {
       });
 
       expect(command).toBe(
-        'npx @hey-api/openapi-ts -i ./api/spec.yaml -o ./src/generated -c @hey-api/client-fetch -p @hey-api/typescript -p @hey-api/sdk',
+        'openapi-ts -i ./api/spec.yaml -o ./src/generated -c @hey-api/client-fetch -p @hey-api/typescript -p @hey-api/sdk',
       );
     });
 
@@ -76,7 +76,7 @@ describe('utils', () => {
       });
 
       expect(command).toBe(
-        'npx @hey-api/openapi-ts -i ./api/spec.yaml -o ./src/generated -c @hey-api/client-fetch -p @tanstack/react-query -p zod',
+        'openapi-ts -i ./api/spec.yaml -o ./src/generated -c @hey-api/client-fetch -p @tanstack/react-query -p zod',
       );
     });
   });

--- a/packages/nx-plugin/src/utils.ts
+++ b/packages/nx-plugin/src/utils.ts
@@ -41,7 +41,7 @@ export function generateClientCommand({
   plugins: Plugin[];
   specFile: string;
 }) {
-  return `npx @hey-api/openapi-ts -i ${specFile} -o ${outputPath} -c ${clientType}${plugins.length > 0 ? ` ${plugins.map((plugin) => `-p ${getPluginName(plugin)}`).join(' ')}` : ''}`;
+  return `openapi-ts -i ${specFile} -o ${outputPath} -c ${clientType}${plugins.length > 0 ? ` ${plugins.map((plugin) => `-p ${getPluginName(plugin)}`).join(' ')}` : ''}`;
 }
 
 /**

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "labels": ["dependencies"],
+  "ignoreDeps": ["@hey-api/openapi-ts"],
+  "packageRules": [
+    {
+      "description": "Nx ecosystem — group all @nx/* and nx into one PR",
+      "matchPackageNames": ["nx", "@nx/*"],
+      "groupName": "Nx ecosystem",
+      "groupSlug": "nx-ecosystem",
+      "automerge": false
+    },
+    {
+      "description": "SWC toolchain",
+      "matchPackageNames": ["@swc-node/*", "@swc/*"],
+      "groupName": "SWC toolchain",
+      "automerge": true,
+      "automergeType": "pr",
+      "minimumReleaseAge": "3 days"
+    },
+    {
+      "description": "Vitest and coverage tooling",
+      "matchPackageNames": ["vitest", "@vitest/*"],
+      "groupName": "Vitest",
+      "automerge": true,
+      "automergeType": "pr",
+      "minimumReleaseAge": "3 days"
+    },
+    {
+      "description": "TypeScript — major bumps need manual review against nx/rollup compat",
+      "matchPackageNames": ["typescript", "typescript-eslint"],
+      "groupName": "TypeScript toolchain",
+      "automerge": false
+    },
+    {
+      "description": "ESLint ecosystem",
+      "matchPackageNames": ["eslint", "@eslint/*", "globals"],
+      "groupName": "ESLint",
+      "automerge": true,
+      "automergeType": "pr",
+      "minimumReleaseAge": "3 days"
+    },
+    {
+      "description": "Build tooling — rollup, vite, tsup",
+      "matchPackageNames": ["rollup", "vite", "tsup"],
+      "groupName": "Build tooling",
+      "automerge": false
+    },
+    {
+      "description": "Runtime deps that affect published package — no automerge",
+      "matchPackageNames": [
+        "@hey-api/json-schema-ref-parser",
+        "api-smart-diff",
+        "swagger2openapi",
+        "@types/swagger2openapi",
+        "latest-version",
+        "xcurl",
+        "tslib"
+      ],
+      "groupName": "Runtime dependencies",
+      "automerge": false
+    },
+    {
+      "description": "Automerge minor/patch for low-risk dev deps",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchPackageNames": [
+        "prettier",
+        "lefthook",
+        "jsdom",
+        "ts-node",
+        "@types/node"
+      ],
+      "automerge": true,
+      "automergeType": "pr",
+      "minimumReleaseAge": "3 days"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

The existing plugin e2e tests only call `nx show project` to assert the inferred `generateApi` target is *defined* — the `openapi-ts` binary is never actually executed. This means the binary-name fix in #24 could pass all tests while silently failing at runtime if the binary were missing from PATH.

This PR adds an e2e test that runs `nx run @tmp/inferred-e2e:generateApi` end-to-end and asserts the generated files (`index.ts`, `types.gen.ts`, `sdk.gen.ts`) are produced. The test:

1. Writes a minimal workspace with an `openapi-ts.config.cjs` and a local OpenAPI spec
2. Executes `nx run @tmp/inferred-e2e:generateApi` via `execFileSync` with `NX_DAEMON=false`
3. Extends `PATH` with the monorepo's `node_modules/.bin` dirs to simulate a real install (the temp workspace has no `node_modules`)
4. Asserts the generated output files exist

## Test plan

- [ ] New e2e test passes locally (`pnpm nx run @seriouslag/nx-openapi-ts-plugin:e2e`) — 35 tests total, new one runs in ~1.7s
- [ ] All CI matrix jobs pass (macos/ubuntu × Node 22/24)

🤖 Generated with [Claude Code](https://claude.com/claude-code)