### PR TITLE
fix(nx-plugin): make update-api atomic and ignore tag-only spec changes

### DIFF
--- a/packages/nx-plugin/src/executors/update-api/updateApi.ts
+++ b/packages/nx-plugin/src/executors/update-api/updateApi.ts
@@ -1,17 +1,12 @@
 import { existsSync, writeFileSync } from 'node:fs';
-import {
-  cp,
-  readFile,
-  rm,
-  watch as fileWatch,
-  writeFile,
-} from 'node:fs/promises';
+import { readFile, watch as fileWatch, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import type { PromiseExecutor } from '@nx/devkit';
 import { logger, names } from '@nx/devkit';
 
 import {
+  atomicReplaceDir,
   bundleAndDereferenceSpecFile,
   cleanupTempFolder,
   compareSpecs,
@@ -274,27 +269,23 @@ const runExecutor: PromiseExecutor<UpdateApiExecutorSchema> = async (
       projectGeneratedDir,
     );
 
-    // Remove old generated directory if it exists
-    if (existsSync(absoluteProjectGeneratedDir)) {
-      logger.debug(
-        `Removing old generated directory: ${absoluteProjectGeneratedDir}`,
-      );
-      await rm(absoluteProjectGeneratedDir, {
-        force: true,
-        recursive: true,
-      });
-      logger.debug(
-        `Old generated directory removed successfully: ${absoluteProjectGeneratedDir}`,
-      );
-    }
-
-    // Copy new generated directory
-    await cp(absoluteGeneratedTempDir, absoluteProjectGeneratedDir, {
-      recursive: true,
-    });
-
+    // Format the freshly generated files in the temp directory *before* swapping
+    // them into place, so the project's generated directory is only ever
+    // replaced with fully-formed, formatted output.
     logger.debug('Formatting generated directory...');
-    await formatFiles(absoluteProjectGeneratedDir);
+    await formatFiles(absoluteGeneratedTempDir);
+
+    // Atomically swap the new generated directory into place. This avoids the
+    // window where the project's generated directory would otherwise be absent
+    // or half-populated (which breaks concurrent `tsc --build` consumers).
+    logger.debug(
+      `Atomically replacing generated directory: ${absoluteProjectGeneratedDir}`,
+    );
+    await atomicReplaceDir(
+      absoluteGeneratedTempDir,
+      absoluteProjectGeneratedDir,
+    );
+    logger.debug(`Generated directory replaced successfully`);
 
     logger.info('Successfully updated API client and spec files.');
     await cleanup(absoluteTempFolder);

--- a/packages/nx-plugin/src/test-specs/tags-changed.json
+++ b/packages/nx-plugin/src/test-specs/tags-changed.json
@@ -1,0 +1,82 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test API",
+    "version": "1.0.0",
+    "description": "A test API for testing spec comparison"
+  },
+  "servers": [
+    {
+      "url": "https://api.example.com/v1",
+      "description": "Production server"
+    }
+  ],
+  "security": [
+    {
+      "apiKey": []
+    }
+  ],
+  "paths": {
+    "/users": {
+      "get": {
+        "summary": "Get all users",
+        "tags": ["Users"],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Number of users to return",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 10
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/User"
+                  }
+                },
+                "example": [
+                  {
+                    "id": 1,
+                    "name": "John Doe"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "apiKey": {
+        "type": "apiKey",
+        "name": "X-API-Key",
+        "in": "header"
+      }
+    }
+  }
+}

--- a/packages/nx-plugin/src/utils.atomic-replace.spec.ts
+++ b/packages/nx-plugin/src/utils.atomic-replace.spec.ts
@@ -1,0 +1,82 @@
+import { randomUUID } from 'node:crypto';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { atomicReplaceDir } from './utils';
+
+describe('atomicReplaceDir', () => {
+  let workDir: string;
+
+  beforeEach(async () => {
+    workDir = await mkdtemp(join(tmpdir(), `atomic-replace-${randomUUID()}-`));
+  });
+
+  afterEach(async () => {
+    await rm(workDir, { force: true, recursive: true });
+  });
+
+  const writeDir = async (dir: string, files: Record<string, string>) => {
+    await mkdir(dir, { recursive: true });
+    for (const [name, contents] of Object.entries(files)) {
+      await writeFile(join(dir, name), contents);
+    }
+  };
+
+  it('replaces the contents of an existing target directory', async () => {
+    const source = join(workDir, 'source');
+    const target = join(workDir, 'target');
+    await writeDir(source, { 'a.txt': 'new-a', 'b.txt': 'new-b' });
+    await writeDir(target, { 'a.txt': 'old-a', 'old-only.txt': 'stale' });
+
+    await atomicReplaceDir(source, target);
+
+    expect(await readFile(join(target, 'a.txt'), 'utf-8')).toBe('new-a');
+    expect(await readFile(join(target, 'b.txt'), 'utf-8')).toBe('new-b');
+    // Stale files from the previous contents must be gone.
+    expect(existsSync(join(target, 'old-only.txt'))).toBe(false);
+  });
+
+  it('creates the target directory when it does not exist', async () => {
+    const source = join(workDir, 'source');
+    const target = join(workDir, 'nested', 'target');
+    await writeDir(source, { 'a.txt': 'a' });
+    await mkdir(join(workDir, 'nested'), { recursive: true });
+
+    await atomicReplaceDir(source, target);
+
+    expect(await readFile(join(target, 'a.txt'), 'utf-8')).toBe('a');
+  });
+
+  it('leaves no staging or backup directories behind', async () => {
+    const source = join(workDir, 'source');
+    const target = join(workDir, 'target');
+    await writeDir(source, { 'a.txt': 'a' });
+    await writeDir(target, { 'a.txt': 'old' });
+
+    await atomicReplaceDir(source, target);
+
+    const leftovers = (await readdir(workDir)).filter(
+      (name) => name.includes('.staging-') || name.includes('.old-'),
+    );
+    expect(leftovers).toEqual([]);
+  });
+
+  it('preserves the original target if staging the source fails', async () => {
+    const source = join(workDir, 'does-not-exist');
+    const target = join(workDir, 'target');
+    await writeDir(target, { 'a.txt': 'original' });
+
+    await expect(atomicReplaceDir(source, target)).rejects.toThrow();
+
+    // The original target must be intact after a failed replace.
+    expect(await readFile(join(target, 'a.txt'), 'utf-8')).toBe('original');
+    const leftovers = (await readdir(workDir)).filter(
+      (name) => name.includes('.staging-') || name.includes('.old-'),
+    );
+    expect(leftovers).toEqual([]);
+  });
+});

--- a/packages/nx-plugin/src/utils.compare-spec.spec.ts
+++ b/packages/nx-plugin/src/utils.compare-spec.spec.ts
@@ -250,4 +250,21 @@ describe('isOperationTagsPath', () => {
   it('does NOT match the top-level tags definition', () => {
     expect(isOperationTagsPath(['tags', 0, 'name'])).toBe(false);
   });
+
+  it('does NOT match tags nested deeper than the operation level', () => {
+    // e.g. a tags array on a callback operation nested under the parent op.
+    expect(
+      isOperationTagsPath([
+        'paths',
+        '/users',
+        'post',
+        'callbacks',
+        'onEvent',
+        '{$request.body#/url}',
+        'post',
+        'tags',
+        0,
+      ]),
+    ).toBe(false);
+  });
 });

--- a/packages/nx-plugin/src/utils.compare-spec.spec.ts
+++ b/packages/nx-plugin/src/utils.compare-spec.spec.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'path';
 import { describe, expect, it } from 'vitest';
 
-import { compareSpecs } from './utils';
+import { compareSpecs, isOperationTagsPath } from './utils';
 
 describe('compareSpecs', () => {
   describe('JSON Specs', () => {
@@ -49,6 +49,14 @@ describe('compareSpecs', () => {
       const areEqual = await compareSpecs(
         resolve(__dirname, './test-specs/base.json'),
         resolve(__dirname, './test-specs/example-changed.json'),
+      );
+      expect(areEqual).toBe(true);
+    });
+
+    it('should ignore operation tags changes', async () => {
+      const areEqual = await compareSpecs(
+        resolve(__dirname, './test-specs/base.json'),
+        resolve(__dirname, './test-specs/tags-changed.json'),
       );
       expect(areEqual).toBe(true);
     });
@@ -202,5 +210,44 @@ describe('compareSpecs', () => {
       );
       expect(areEqual).toBe(false);
     });
+  });
+});
+
+describe('isOperationTagsPath', () => {
+  it('matches an operation tags array entry', () => {
+    expect(isOperationTagsPath(['paths', '/users', 'get', 'tags', 0])).toBe(
+      true,
+    );
+  });
+
+  it('matches the operation tags array itself', () => {
+    expect(isOperationTagsPath(['paths', '/users', 'post', 'tags'])).toBe(true);
+  });
+
+  it('is case-insensitive about the HTTP method', () => {
+    expect(isOperationTagsPath(['paths', '/users', 'GET', 'tags', 1])).toBe(
+      true,
+    );
+  });
+
+  it('does NOT match a schema property named "tags"', () => {
+    expect(
+      isOperationTagsPath([
+        'components',
+        'schemas',
+        'User',
+        'properties',
+        'tags',
+      ]),
+    ).toBe(false);
+  });
+
+  it('does NOT match tags not preceded by an HTTP method', () => {
+    expect(isOperationTagsPath(['paths', '/users', 'tags'])).toBe(false);
+    expect(isOperationTagsPath(['tags'])).toBe(false);
+  });
+
+  it('does NOT match the top-level tags definition', () => {
+    expect(isOperationTagsPath(['tags', 0, 'name'])).toBe(false);
   });
 });

--- a/packages/nx-plugin/src/utils.ts
+++ b/packages/nx-plugin/src/utils.ts
@@ -1,12 +1,15 @@
 import { existsSync, lstatSync } from 'node:fs';
 import {
+  cp,
   mkdir,
   readdir,
   readFile,
+  rename,
   rm,
   rmdir,
   writeFile,
 } from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
 import {
   basename,
   dirname,
@@ -281,6 +284,37 @@ export function removeExamples(spec: JSONSchema) {
   return spec;
 }
 
+const HTTP_METHODS = new Set([
+  'connect',
+  'delete',
+  'get',
+  'head',
+  'options',
+  'patch',
+  'post',
+  'put',
+  'trace',
+]);
+
+/**
+ * True when a diff path points at an operation's `tags` array, i.e.
+ * `paths.<route>.<method>.tags[.<index>]`. Used to ignore tag-only changes,
+ * which do not affect generated client code. Deliberately does NOT match a
+ * schema property that merely happens to be named "tags".
+ */
+export function isOperationTagsPath(path: (string | number)[]): boolean {
+  const tagsIndex = path.indexOf('tags');
+  if (tagsIndex < 2) {
+    return false;
+  }
+  const method = path[tagsIndex - 1];
+  return (
+    path[0] === 'paths' &&
+    typeof method === 'string' &&
+    HTTP_METHODS.has(method.toLowerCase())
+  );
+}
+
 /**
  * Fetches two spec files and compares them for differences
  */
@@ -312,9 +346,32 @@ export async function compareSpecs(
     if (diff.path.includes('examples') || diff.path.includes('example')) {
       return false;
     }
+    // Operation-level `tags` are organizational metadata only — they are not
+    // emitted into the generated client by openapi-ts, so a tags-only delta
+    // must not count as a spec change. Otherwise the client is needlessly
+    // regenerated on every run (which churns the generated directory).
+    //
+    // Match ONLY `paths.<route>.<method>.tags[...]` — not a schema property
+    // that merely happens to be named "tags", and not `summary`/`description`
+    // (those ARE emitted as JSDoc on the generated SDK, so they affect output).
+    if (isOperationTagsPath(diff.path)) {
+      return false;
+    }
     return true;
   });
   const areSpecsEqual = filteredDiffs.length === 0;
+
+  if (!areSpecsEqual) {
+    logger.debug(
+      `Found ${filteredDiffs.length} significant diff(s): ${JSON.stringify(
+        filteredDiffs.map((diff) => ({
+          action: diff.action,
+          path: Array.isArray(diff.path) ? diff.path.join('.') : diff.path,
+          type: diff.type,
+        })),
+      )}`,
+    );
+  }
 
   logger.debug(`Are specs equal: ${areSpecsEqual}`);
   return areSpecsEqual;
@@ -344,6 +401,52 @@ export function isAFile(isFileSystemFile: string) {
  */
 export async function makeDir(path: string) {
   await mkdir(path, { recursive: true });
+}
+
+/**
+ * Atomically replaces `targetDir` with the contents of `sourceDir`.
+ *
+ * The naive approach (rm -rf targetDir; cp sourceDir targetDir) leaves
+ * `targetDir` absent or half-populated for the duration of the copy. When the
+ * target is consumed by a concurrent task (e.g. `tsc --build` reading committed
+ * generated sources), that window causes spurious "cannot find module" errors.
+ *
+ * Instead we stage the new contents next to the target and swap directories with
+ * `rename`, which is atomic within a filesystem. On any failure the original
+ * `targetDir` is left untouched.
+ */
+export async function atomicReplaceDir(
+  sourceDir: string,
+  targetDir: string,
+): Promise<void> {
+  const suffix = randomUUID();
+  const stagingDir = `${targetDir}.staging-${suffix}`;
+  const backupDir = `${targetDir}.old-${suffix}`;
+
+  // Stage the new contents on the same filesystem as the target so the
+  // subsequent renames are atomic.
+  await cp(sourceDir, stagingDir, { recursive: true });
+
+  try {
+    const targetExists = existsSync(targetDir);
+    if (targetExists) {
+      await rename(targetDir, backupDir);
+    }
+    try {
+      await rename(stagingDir, targetDir);
+    } catch (error) {
+      // Swap-in failed: restore the original directory before rethrowing.
+      if (targetExists && !existsSync(targetDir)) {
+        await rename(backupDir, targetDir);
+      }
+      throw error;
+    }
+  } catch (error) {
+    await rm(stagingDir, { force: true, recursive: true });
+    throw error;
+  } finally {
+    await rm(backupDir, { force: true, recursive: true });
+  }
 }
 
 /**

--- a/packages/nx-plugin/src/utils.ts
+++ b/packages/nx-plugin/src/utils.ts
@@ -303,13 +303,13 @@ const HTTP_METHODS = new Set([
  * schema property that merely happens to be named "tags".
  */
 export function isOperationTagsPath(path: (string | number)[]): boolean {
-  const tagsIndex = path.indexOf('tags');
-  if (tagsIndex < 2) {
-    return false;
-  }
-  const method = path[tagsIndex - 1];
+  // OpenAPI operation tags live at exactly `paths.<route>.<method>.tags[.<i>]`.
+  // Match that fixed position only — using indexOf would also match `tags`
+  // nested deeper (e.g. under a callback operation), which we must not ignore.
+  const method = path[2];
   return (
     path[0] === 'paths' &&
+    path[3] === 'tags' &&
     typeof method === 'string' &&
     HTTP_METHODS.has(method.toLowerCase())
   );
@@ -422,6 +422,10 @@ export async function atomicReplaceDir(
   const suffix = randomUUID();
   const stagingDir = `${targetDir}.staging-${suffix}`;
   const backupDir = `${targetDir}.old-${suffix}`;
+  // Only delete the backup once the target is safely in place — either the new
+  // dir swapped in, or the original was restored. If both the swap-in and the
+  // restore fail, the backup is the sole intact copy and must be preserved.
+  let backupSafeToDelete = false;
 
   // Stage the new contents on the same filesystem as the target so the
   // subsequent renames are atomic.
@@ -434,10 +438,12 @@ export async function atomicReplaceDir(
     }
     try {
       await rename(stagingDir, targetDir);
+      backupSafeToDelete = true;
     } catch (error) {
       // Swap-in failed: restore the original directory before rethrowing.
       if (targetExists && !existsSync(targetDir)) {
         await rename(backupDir, targetDir);
+        backupSafeToDelete = true;
       }
       throw error;
     }
@@ -445,7 +451,9 @@ export async function atomicReplaceDir(
     await rm(stagingDir, { force: true, recursive: true });
     throw error;
   } finally {
-    await rm(backupDir, { force: true, recursive: true });
+    if (backupSafeToDelete) {
+      await rm(backupDir, { force: true, recursive: true });
+    }
   }
 }
 


### PR DESCRIPTION
## Problem

Consumers of the committed `src/generated` sources (via TS project references) intermittently failed with `error TS2307: Cannot find module './generated/client.gen.js'` during `tsc --build`. Root cause is the `update-api` executor:

1. **It regenerated on every run.** `compareSpecs` treated *any* non-example diff as a spec change. In practice the upstream spec carried operation `tags` (e.g. an extra `"Mocks"` tag) that the committed `spec.yaml` lacked. `tags` are not emitted into the generated client by openapi-ts, so this was pure churn — but it forced regeneration every time the Nx cache missed.
2. **Regeneration was non-atomic.** It did `rm -rf src/generated` then `cp` from a temp dir. A concurrent `tsc --build` reading `src/generated` during that window saw missing files → TS2307.

## Fix

- **`compareSpecs`** now ignores operation-level `tags` diffs (`paths.<route>.<method>.tags`), so a tags-only delta hits the existing no-op early-return instead of regenerating. Scoped precisely so a schema property named `tags` and `summary`/`description` changes (which openapi-ts *does* emit as JSDoc) are still treated as real changes.
- **`atomicReplaceDir`** stages the new generated output in a sibling dir and swaps it in via `rename` (atomic within a filesystem). The target is never absent or half-populated; on failure the original is left intact.

## Tests

- `isOperationTagsPath` unit tests (operation tags vs. schema property named `tags` vs. top-level tags).
- `tags-changed.json` fixture: tags-only delta → `compareSpecs` returns equal.
- `atomicReplaceDir` real-FS tests including "failure leaves original intact" and "no staging/backup leftovers".
- Full suite: **130 unit tests pass**, lint clean.

## Verified end-to-end

Built locally and linked into the consuming monorepo: the real spec now reports `No changes detected → Skipping client code generation` (no `rm`, no regen), and the `--force` path uses the atomic swap and produces byte-identical output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Client regeneration now uses an atomic swap for the generated output directory to minimize the chance of missing or partially updated files.

* **Bug Fixes**
  * Changes limited to operation-level `tags` no longer trigger unnecessary client regeneration.
  * Regeneration failures now preserve the previously generated output.

* **Tests**
  * Added coverage for atomic directory replacement, including failure and cleanup scenarios.
  * Expanded spec-diff behavior tests and added a sample OpenAPI spec for validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->