### PR TITLE
chore: pin pnpm 11 and approve lefthook build script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,6 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 9
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/preview-publish.yml
+++ b/.github/workflows/preview-publish.yml
@@ -95,7 +95,6 @@ jobs:
         if: ${{ steps.gate.outputs.authorized == 'true' }}
         name: Install pnpm
         with:
-          version: 9
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,7 +68,6 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 9
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/sync-openapi.yml
+++ b/.github/workflows/sync-openapi.yml
@@ -31,7 +31,6 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 9
           run_install: false
 
       - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -9,6 +9,16 @@ Under the hood it uses [@hey-api/openapi-ts](https://github.com/hey-api/openapi-
 
 This plugin helps generate packages to be linked correctly in the NX environment and to provide executors to update the client code when an change in the spec file is detected.
 
+## Prerequisites
+
+This repo is pinned to **pnpm 11** via the `packageManager` field in `package.json`. Use [Corepack](https://nodejs.org/api/corepack.html) so your local pnpm matches the pinned version (and CI):
+
+```bash
+corepack enable
+```
+
+Corepack ships with Node and will automatically run the pinned pnpm version inside this repo. Running an older pnpm (e.g. pnpm 9) here will not honour the `allowBuilds` setting and installs may fail with `ERR_PNPM_IGNORED_BUILDS`.
+
 ## install dependencies
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@seriouslag/source",
   "version": "0.0.0",
   "license": "MIT",
+  "packageManager": "pnpm@11.5.2",
   "scripts": {
     "build": "nx run-many --target=build",
     "typecheck": "nx run-many --target=typecheck",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,10 +2,10 @@ packages:
   - apps/*
   - packages/*
 
-onlyBuiltDependencies:
-  - '@swc/core'
-  - '@tailwindcss/oxide'
-  - esbuild
-  - lefthook
-  - nx
-  - unrs-resolver
+allowBuilds:
+  '@swc/core': true
+  '@tailwindcss/oxide': true
+  esbuild: true
+  lefthook: true
+  nx: true
+  unrs-resolver: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,5 +6,6 @@ onlyBuiltDependencies:
   - '@swc/core'
   - '@tailwindcss/oxide'
   - esbuild
+  - lefthook
   - nx
   - unrs-resolver


### PR DESCRIPTION
## What

- Add `"packageManager": "pnpm@11.5.2"` to the root `package.json`.
- Remove the hardcoded `version: 9` from all four workflows' `pnpm/action-setup@v4` steps so the action resolves the version from `packageManager`.
- Add `lefthook` to `onlyBuiltDependencies` in `pnpm-workspace.yaml`.

## Why

Local development runs pnpm 11 while CI pinned pnpm **9** in every `action-setup` step. That skew means pnpm-11 behaviours never run in CI — most visibly, pnpm 11's build-script approval gate (`onlyBuiltDependencies`). `lefthook` ships a postinstall build script that pnpm 11 refuses to run unless approved, so a fresh pnpm-11 install locally trips on it during the pre-commit hook.

Pinning the toolchain via `packageManager` makes local and CI use the same pnpm major, and adding `lefthook` to the approved list silences the build-script gate. The lockfile is already `lockfileVersion: 9.0` (compatible with pnpm 9–11), so no lockfile migration is needed.

## Notes

- This bumps CI's effective pnpm from 9 → 11. `actions/setup-node` here uses a separate `actions/cache` step (not `cache: pnpm`), and `action-setup` still runs after `setup-node`, so ordering is unaffected.
- Independent of the codegen-race fix in #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned the repo to `pnpm@11.5.2` via the `packageManager` setting.
  * Updated CI workflows to streamline pnpm setup by disabling the action’s auto-install and using explicit install steps.
  * Adjusted workspace build controls by switching to an `allowBuilds` allowlist with the same permitted packages.
* **Documentation**
  * Updated prerequisites to recommend Corepack so local pnpm matches the pinned version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->