### PR TITLE
ci: fix release changelog generation with git-cliff

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,9 +128,12 @@ jobs:
         uses: orhun/git-cliff-action@v4
         with:
           config: cliff.toml
+          # `--prepend` writes the new entry into CHANGELOG.md in place. Do NOT
+          # also set the OUTPUT env (git-cliff's -o): newer git-cliff rejects
+          # -o and -p pointing at the same file ("'-o' and '-p' can only be
+          # used together if they point to different files").
           args: --tag ${{ steps.tag.outputs.tag }} --unreleased --prepend CHANGELOG.md
         env:
-          OUTPUT: CHANGELOG.md
           GITHUB_REPO: ${{ github.repository }}
 
       - name: Create release artifacts and push


### PR DESCRIPTION
## Problem

The Release workflow failed on the **Generate changelog entry** step after the latest merges to main:

```
Error: ArgumentError("'-o' and '-p' can only be used together if they point to different files")
```

The `orhun/git-cliff-action@v4` step set **both**:
- `OUTPUT: CHANGELOG.md` (env → git-cliff `-o/--output`)
- `--prepend CHANGELOG.md` (`-p`) in `args`

A newer git-cliff (v2.13.1, bundled by the action) now rejects `-o` and `-p` pointing at the **same** file. This is a pre-existing latent bug in the release pipeline — it surfaced on the first release triggered after #27/#28 merged, not because of those changes.

## Fix

`--prepend CHANGELOG.md` already writes the new entry into the file in place, so the `OUTPUT` env is redundant. Removed it. Added a comment explaining why the two must not both point at `CHANGELOG.md`.

## Note

Once merged, the release for the already-merged `fix(nx-plugin): ...` (#27) commit should be re-triggerable (the changelog/tag/publish never completed for it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow to generate changelog entries more reliably.
  * Removed a conflicting changelog output setting so releases can update the changelog in place without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->